### PR TITLE
Disable numerical safety with a flag

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 *.pyc
 *.coverage
 dist/
+*.xml

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@
 - [Usage](#usage)
 - [On Topologies](#topologies)
 - [On Ordering](#ordering)
+- [Dealing with imperfect Data](#dealing-with-imperfect-data)
 - [Related projects](#related-projects)
 - [License](#license)
 
@@ -209,6 +210,18 @@ cfg.sorting = "value" # default sorting
 
 ```
 At this time only `"off"` and `"value"` are supported. For more sophisticated sorting algorithms the user has to write custom functions.
+
+## Dealing with imperfect Data
+
+When dealing with data, that has measurement uncertainty or other issues like backgrounds, it is sometimes easier to just process the data and remove all `inf` or `nan` values. 
+These values will usually trigger `ValueError` in `decayangle`. This behaviour can be disabled via the config as
+
+```python
+from decayangle.config import config as cfg
+cfg.numerical_safety_checks = False
+```
+Now `nan` and `inf` will be handeled only by `numpy` internally.
+
 ## Related projects
 
 Amplitude analyses dealing with non-zero spin of final-state particles have to implement wigner rotations in some way.

--- a/README.md
+++ b/README.md
@@ -1,9 +1,5 @@
 # Welcome to the decayangle software Project
 
-<!-- [![PyPI - Version](https://img.shields.io/pypi/v/decayangle.svg)](https://pypi.org/project/decayangle)
-[![PyPI - Python Version](https://img.shields.io/pypi/pyversions/decayangle.svg)](https://pypi.org/project/decayangle) -->
-
-
 [![PyPI - Version](https://img.shields.io/pypi/v/decayangle.svg)](https://pypi.org/project/decayangle/)
 [![PyPI - Python Version](https://img.shields.io/pypi/pyversions/decayangle.svg)](https://pypi.org/project/decayangle/)
 [![codecov](https://codecov.io/gh/KaiHabermann/decayangle/graph/badge.svg?token=KXBO8KEQ3V)](https://codecov.io/gh/KaiHabermann/decayangle)

--- a/notebooks/decay_example.ipynb
+++ b/notebooks/decay_example.ipynb
@@ -2,20 +2,20 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 244,
+   "execution_count": 1,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Requirement already satisfied: particle in /home/kai/anaconda3/envs/decayangle_dev/lib/python3.11/site-packages (0.23.1)\n",
-      "Requirement already satisfied: attrs>=19.2 in /home/kai/anaconda3/envs/decayangle_dev/lib/python3.11/site-packages (from particle) (23.2.0)\n",
-      "Requirement already satisfied: hepunits>=2.0.0 in /home/kai/anaconda3/envs/decayangle_dev/lib/python3.11/site-packages (from particle) (2.3.3)\n",
-      "Requirement already satisfied: typing-extensions>=4.5 in /home/kai/anaconda3/envs/decayangle_dev/lib/python3.11/site-packages (from particle) (4.10.0)\n",
+      "Requirement already satisfied: particle in /home/kai/anaconda3/envs/decayangle/lib/python3.12/site-packages (0.23.1)\n",
+      "Requirement already satisfied: attrs>=19.2 in /home/kai/anaconda3/envs/decayangle/lib/python3.12/site-packages (from particle) (23.2.0)\n",
+      "Requirement already satisfied: hepunits>=2.0.0 in /home/kai/anaconda3/envs/decayangle/lib/python3.12/site-packages (from particle) (2.3.3)\n",
+      "Requirement already satisfied: typing-extensions>=4.5 in /home/kai/anaconda3/envs/decayangle/lib/python3.12/site-packages (from particle) (4.10.0)\n",
       "Note: you may need to restart the kernel to use updated packages.\n",
-      "Requirement already satisfied: sympy in /home/kai/anaconda3/envs/decayangle_dev/lib/python3.11/site-packages (1.12)\n",
-      "Requirement already satisfied: mpmath>=0.19 in /home/kai/anaconda3/envs/decayangle_dev/lib/python3.11/site-packages (from sympy) (1.3.0)\n",
+      "Requirement already satisfied: sympy in /home/kai/anaconda3/envs/decayangle/lib/python3.12/site-packages (1.12)\n",
+      "Requirement already satisfied: mpmath>=0.19 in /home/kai/anaconda3/envs/decayangle/lib/python3.12/site-packages (from sympy) (1.3.0)\n",
       "Note: you may need to restart the kernel to use updated packages.\n"
      ]
     }
@@ -37,16 +37,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 245,
+   "execution_count": 2,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "( 0 -> ( (2, 3) -> 2, 3 ), 1 )\n",
-      "( 0 -> ( (1, 3) -> 1, 3 ), 2 )\n",
-      "( 0 -> ( (1, 2) -> 1, 2 ), 3 )\n"
+      "Topology: ( 0 -> ( (2, 3) -> 2, 3 ), 1 )\n",
+      "Topology: ( 0 -> ( (1, 3) -> 1, 3 ), 2 )\n",
+      "Topology: ( 0 -> ( (1, 2) -> 1, 2 ), 3 )\n"
      ]
     }
    ],
@@ -70,7 +70,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 246,
+   "execution_count": 3,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -213,7 +213,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 247,
+   "execution_count": 4,
    "metadata": {},
    "outputs": [
     {
@@ -282,7 +282,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 248,
+   "execution_count": 5,
    "metadata": {},
    "outputs": [
     {
@@ -322,24 +322,50 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 249,
+   "execution_count": 6,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "( 0 -> ( (2, 3) -> 2, 3 ), 1 ) {((2, 3), 1): (3.141592653589793, -1.1917396523105919)}\n",
-      "( 0 -> ( (1, 3) -> 1, 3 ), 2 ) {((1, 3), 2): (5.951828758370096e-17, -0.23908244819164334)}\n",
-      "( 0 -> ( (1, 2) -> 1, 2 ), 3 ) {((1, 2), 3): (5.041182631349134e-17, -0.26891484091188184)}\n"
+      "Topology: ( 0 -> ( (2, 3) -> 2, 3 ), 1 ) {((2, 3), 1): HelicityAngles(theta_rf=-0.17491891382569247, psi_rf=-1.5707963267948966), (2, 3): HelicityAngles(theta_rf=-1.1917396523105919, psi_rf=3.141592653589793)}\n",
+      "Topology: ( 0 -> ( (1, 3) -> 1, 3 ), 2 ) {((1, 3), 2): HelicityAngles(theta_rf=-3.136500881413798, psi_rf=-1.5707963267948966), (1, 3): HelicityAngles(theta_rf=-0.23908244819164334, psi_rf=5.951828758370096e-17)}\n",
+      "Topology: ( 0 -> ( (1, 2) -> 1, 2 ), 3 ) {((1, 2), 3): HelicityAngles(theta_rf=-2.753684909312669, psi_rf=1.5707963267948966), (1, 2): HelicityAngles(theta_rf=-0.26891484091188184, psi_rf=5.041182631349134e-17)}\n"
      ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/home/kai/LHCb/decayangle/src/decayangle/kinematics.py:315: RuntimeWarning: invalid value encountered in divide\n",
+      "  cosine_input = cb.where(abs(abs_mom) <= tol, 0, z_component(v) / abs_mom)\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "{((2, 3),\n",
+       "  1): HelicityAngles(theta_rf=-0.17491891382569247, psi_rf=-1.5707963267948966),\n",
+       " (2,\n",
+       "  3): HelicityAngles(theta_rf=-1.1917396523105919, psi_rf=3.141592653589793)}"
+      ]
+     },
+     "execution_count": 6,
+     "metadata": {},
+     "output_type": "execute_result"
     }
    ],
    "source": [
     "for topology in tg.topologies:\n",
     "        final_state_rotations = reference_topology.relative_wigner_angles(topology, momenta)\n",
     "        isobars = topology.helicity_angles(momenta)\n",
-    "        print(topology, isobars)"
+    "        print(topology, isobars)\n",
+    "\n",
+    "topo = tg.topologies[0]\n",
+    "hel = topo.helicity_angles(momenta)\n",
+    "for k, v in hel.items():\n",
+    "    print(k, v)"
    ]
   },
   {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ packages = ["src/decayangle"]
 [project]
 name = "decayangle"
 description = 'A tool for wigner rotations in n-body decays'
-version = '1.0.1'
+version = '1.0.2'
 readme = "README.md"
 requires-python = ">=3.8"
 license = "MIT"
@@ -65,4 +65,4 @@ cov = 'pytest --cov-report=term-missing --cov-report=xml --cov-config=pyproject.
 
 [[tool.hatch.envs.test.matrix]]
 python = ["312", "311", "310", "39", "38"] 
-version = ["1.0.1"]
+version = ["1.0.2"]

--- a/src/decayangle/config.py
+++ b/src/decayangle/config.py
@@ -5,6 +5,7 @@ class _cfg:
     __state = {
         "backend": "numpy",
         "sorting": "value",
+        "numerical_safety_checks": True,
     }
     backend_map = {
         "jax": jax_backend,
@@ -40,6 +41,16 @@ class _cfg:
                 "Only 'value' and 'off' are allowed for the time being"
             )
         self.__state["sorting"] = value
+    
+    @property
+    def numerical_safety_checks(self):
+        return self.__state["numerical_safety_checks"]
+    
+    @numerical_safety_checks.setter
+    def numerical_safety_checks(self, value:bool):
+        if not isinstance(value, bool):
+            raise ValueError(f"Value {value} or type {type(value)} not understood for numerical_safety_checks")
+        self.__state["numerical_safety_checks"] = value
 
     def __value_sorting_fun(self, value):
         """Sort the value by lenght of the tuple first and then by absolute value of the integers
@@ -79,6 +90,10 @@ class _cfg:
             return value
 
         raise ValueError(f"Node sorting {self.sorting} not found")
+    
+    def raise_if_safety_on(self, exception: Exception):
+        if self.safety_checks:
+            raise exception
 
 
 config = _cfg()

--- a/src/decayangle/config.py
+++ b/src/decayangle/config.py
@@ -43,7 +43,7 @@ class _cfg:
         self.__state["sorting"] = value
     
     @property
-    def numerical_safety_checks(self):
+    def numerical_safety_checks(self) -> bool:
         return self.__state["numerical_safety_checks"]
     
     @numerical_safety_checks.setter
@@ -92,7 +92,7 @@ class _cfg:
         raise ValueError(f"Node sorting {self.sorting} not found")
     
     def raise_if_safety_on(self, exception: Exception):
-        if self.safety_checks:
+        if self.numerical_safety_checks:
             raise exception
 
 

--- a/src/decayangle/decay_topology.py
+++ b/src/decayangle/decay_topology.py
@@ -282,8 +282,10 @@ class Node:
             cb.ones_like(akm.gamma(self.momentum(momenta))),
         ):
             gamma = akm.gamma(self.momentum(momenta))
-            raise ValueError(
-                f"gamma = {gamma} For the time being only particles at rest are supported as start nodes for a boost. This will be fixed in the future."
+            cfg.raise_if_safety_on( 
+                ValueError(
+                    f"gamma = {gamma} For the time being only particles at rest are supported as start nodes for a boost. This will be fixed in the future."
+                )
             )
         target = Node.get_node(target)
         zero = cb.zeros_like(akm.time_component(self.momentum(momenta)))
@@ -362,9 +364,11 @@ class Node:
             cb.ones_like(akm.gamma(self.momentum(momenta))),
         ):
             gamma = akm.gamma(self.momentum(momenta))
-            raise ValueError(
-                f"gamma = {gamma} For the time being only particles at rest are supported as start nodes for a boost. This will be fixed in the future."
-            )
+            cfg.raise_if_safety_on(
+                ValueError(
+                    f"gamma = {gamma} For the time being only particles at rest are supported as start nodes for a boost. This will be fixed in the future."
+                )
+            ) 
         zero = cb.zeros_like(akm.time_component(self.momentum(momenta)))
         if self.value == target.value:
             return LorentzTrafo(zero, zero, zero, zero, zero, zero)

--- a/src/decayangle/kinematics.py
+++ b/src/decayangle/kinematics.py
@@ -305,8 +305,10 @@ def decode_4_4(matrix, tol=1e-14):
     # for large deviations we will raise an exception
     gma = cb.where((abs(gma) < 1) & (abs(gma - 1) < 1e-14), 1, gma)
     if cb.any(gma < 1):
-        raise ValueError(
-            f"gamma is {gma}, which is less than 1. This is not a valid Lorentz transformation"
+        cfg.raise_if_safety_on(
+             ValueError(
+                f"gamma is {gma}, which is less than 1. This is not a valid Lorentz transformation"
+            )
         )
 
     xi = cb.arccosh(gma)
@@ -374,12 +376,14 @@ def adjust_for_2pi_rotation(
         cb.all(cb.isclose(m_original_2x2, new_2x2, atol=3e-2), axis=-1), axis=-1
     )
     if cb.any(not_two_pi_shifted & two_pi_shifted):
-        raise ValueError(
-            f"The 2x2 matrix does not match the reconstruced parameters!"
-            f"This can happen due to numerical errors."
-            f"The original matrix is {m_original_2x2} and the reconstructed matrix is {new_2x2}"
-            f"Difference is {m_original_2x2 - new_2x2}"
-            f"Parameters are {phi}, {theta}, {xi}, {theta_rf}, {phi_rf}, {psi_rf}"
+        cfg.raise_if_safety_on(
+             ValueError(
+                f"The 2x2 matrix does not match the reconstruced parameters!"
+                f"This can happen due to numerical errors."
+                f"The original matrix is {m_original_2x2} and the reconstructed matrix is {new_2x2}"
+                f"Difference is {m_original_2x2 - new_2x2}"
+                f"Parameters are {phi}, {theta}, {xi}, {theta_rf}, {phi_rf}, {psi_rf}"
+            )
         )
 
     psi_rf = cb.where(two_pi_shifted, psi_rf + 2 * cb.pi, psi_rf)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,28 @@
+import pytest
+import numpy as np
+from decayangle.config import config as cfg
+from decayangle.decay_topology import TopologyCollection
+
+def test_numerical_safety_checks():
+    cfg.numerical_safety_checks = True
+
+    momenta = {
+        1: np.array([0.15, 0, 0, 1]),
+        2: np.array([-0.5, 0.001, 0.2, 2]),
+        3: np.array([0.1, 0.4, 0.2, 1.3]),
+    }
+
+    tc = TopologyCollection(0, [1, 2, 3])
+
+    for topology in tc.topologies:
+        pytest.raises(ValueError, topology.helicity_angles, momenta)
+
+    cfg.numerical_safety_checks = False
+    cfg.sorting = "off"
+    for topology in tc.topologies:
+        topology.helicity_angles(momenta)
+
+
+if __name__ == "__main__":
+    test_numerical_safety_checks()
+


### PR DESCRIPTION
Add the ability to disable the numerical safety checks, like the check for rest frame systems and so on.
This may be needed for data, which is not perfectly sanitized or contains background or measurement uncertainty.
Here you can then possibly drop all values which become nan or +-inf.
