### PR TITLE
Better definition of boosts, so that they are dependend on the particle ordering

### DIFF
--- a/tests/test_lorentz.py
+++ b/tests/test_lorentz.py
@@ -400,57 +400,57 @@ def test_helicity_angles():
     momenta = tree1.to_rest_frame(momenta)
     momenta_23_rotated = tree1.root.transform(rotation, momenta)
     assert np.allclose(
-        np.cos(tree1.helicity_angles(momenta_23_rotated)[((2, 3), 1)].theta_rf),
-        np.cos(chain_vars["Kpi"]["theta_Kst"]),
+        tree1.helicity_angles(momenta_23_rotated)[((2, 3), 1)].theta_rf,
+        chain_vars["Kpi"]["theta_Kst"],
     )
     assert np.allclose(
-        np.cos(tree1.helicity_angles(momenta_23_rotated)[((2, 3), 1)].psi_rf),
-        np.cos(chain_vars["Kpi"]["phi_Kst"]),
+        tree1.helicity_angles(momenta_23_rotated)[((2, 3), 1)].psi_rf,
+        chain_vars["Kpi"]["phi_Kst"],
     )
     assert np.allclose(
-        np.cos(tree1.helicity_angles(momenta_23_rotated)[(2, 3)].psi_rf),
-        np.cos(chain_vars["Kpi"]["phi_K"]),
+        tree1.helicity_angles(momenta_23_rotated)[(2, 3)].psi_rf,
+        chain_vars["Kpi"]["phi_K"],
     )
     assert np.allclose(
-        np.cos(tree1.helicity_angles(momenta_23_rotated)[(2, 3)].theta_rf),
-        np.cos(chain_vars["Kpi"]["theta_K"]),
+        tree1.helicity_angles(momenta_23_rotated)[(2, 3)].theta_rf,
+        chain_vars["Kpi"]["theta_K"],
         1e-4,
     )
 
     assert np.allclose(
-        np.cos(tree2.helicity_angles(momenta_23_rotated)[((3, 1), 2)].theta_rf),
-        np.cos(chain_vars["pip"]["theta_D"]),
+        tree2.helicity_angles(momenta_23_rotated)[((3, 1), 2)].theta_rf,
+        chain_vars["pip"]["theta_D"],
     )
     assert np.allclose(
-        np.cos(tree2.helicity_angles(momenta_23_rotated)[((3, 1), 2)].psi_rf),
-        np.cos(chain_vars["pip"]["phi_D"]),
-    )
-
-    assert np.allclose(
-        np.cos(tree2.helicity_angles(momenta_23_rotated)[(3, 1)].psi_rf),
-        np.cos(chain_vars["pip"]["phi_pi"]),
-    )
-    assert np.allclose(
-        np.cos(tree2.helicity_angles(momenta_23_rotated)[(3, 1)].theta_rf),
-        np.cos(chain_vars["pip"]["theta_pi"]),
+        tree2.helicity_angles(momenta_23_rotated)[((3, 1), 2)].psi_rf,
+        chain_vars["pip"]["phi_D"],
     )
 
     assert np.allclose(
-        np.cos(tree3.helicity_angles(momenta_23_rotated)[((1, 2), 3)].theta_rf),
-        np.cos(chain_vars["pK"]["theta_L"]),
+        tree2.helicity_angles(momenta_23_rotated)[(3, 1)].psi_rf,
+        chain_vars["pip"]["phi_pi"],
     )
     assert np.allclose(
-        np.cos(tree3.helicity_angles(momenta_23_rotated)[((1, 2), 3)].psi_rf),
-        np.cos(chain_vars["pK"]["phi_L"]),
+        tree2.helicity_angles(momenta_23_rotated)[(3, 1)].theta_rf,
+        chain_vars["pip"]["theta_pi"],
+    )
+
+    assert np.allclose(
+        tree3.helicity_angles(momenta_23_rotated)[((1, 2), 3)].theta_rf,
+        chain_vars["pK"]["theta_L"],
     )
     assert np.allclose(
-        np.cos(tree3.helicity_angles(momenta_23_rotated)[(1, 2)].psi_rf),
-        np.cos(chain_vars["pK"]["Lphi_p"]),
+        tree3.helicity_angles(momenta_23_rotated)[((1, 2), 3)].psi_rf,
+        chain_vars["pK"]["phi_L"],
+    )
+    assert np.allclose(
+        tree3.helicity_angles(momenta_23_rotated)[(1, 2)].psi_rf,
+        chain_vars["pK"]["Lphi_p"],
         1e-4,
     )
     assert np.allclose(
-        np.cos(tree3.helicity_angles(momenta_23_rotated)[(1, 2)].theta_rf),
-        np.cos(chain_vars["pK"]["Ltheta_p"]),
+        tree3.helicity_angles(momenta_23_rotated)[(1, 2)].theta_rf,
+        chain_vars["pK"]["Ltheta_p"],
         1e-4,
     )
 
@@ -504,7 +504,8 @@ def test_conventions(momenta):
 
 
 if __name__ == "__main__":
-    # test_lotentz(boost_definitions())
-    # test_lotentz2(boost_definitions())
-    # test_helicity_angles()
+    test_lotentz(boost_definitions())
+    test_lotentz2(boost_definitions())
+    test_helicity_angles()
     test_conventions(np.random.rand(4, 3))
+    test_daltiz_plot_decomposition([np.random.rand(3, 100, 3) for _ in range(3)])

--- a/tests/test_particle2.py
+++ b/tests/test_particle2.py
@@ -7,7 +7,7 @@ import numpy as np
 
 def test_particle2():
     cfg.sorting = "off"
-    topo1 = Topology(0, (1, (2, 3)))
+    topo1 = Topology(0, ((2, 3), 1))
     topo2 = Topology(0, ((3, 2), 1))
     print("Topology 1:", topo1)
     print("Topology 2:", topo2)
@@ -17,37 +17,22 @@ def test_particle2():
         2: np.array([0.466794284860449, 0.0, 0.1935604618890383, 0.7064556158132482]),
         3: np.array([-0.466794284860449, 0.0, 0.2437988784199448, 0.5448069221267302]),
     }
-    x, y = np.linspace(-np.pi + 1e-5, np.pi - 1e-5, 100), np.linspace(
-        -np.pi + 1e-5, np.pi - 1e-5, 100
+    x, y = np.linspace(-np.pi + 1e-5, np.pi - 1e-5, 30), np.linspace(
+        -np.pi + 1e-5, np.pi - 1e-5, 30
     )
     X, Y = np.meshgrid(x, y)
     rotation = LorentzTrafo(0, 0, 0, X, 1.0, Y)
     momenta = {i: rotation.matrix_4x4 @ p for i, p in momenta.items()}
     wigner_angles = topo1.relative_wigner_angles(topo2, momenta)
 
-    for particle in [1, 2, 3]:
-        # this will always be 0, since the chain of boosts and rotations into the particle i rest frame is order independent
-        # this is, because the final state frame is determined by the boost axis from the second to last frame into the last frame. This is not ordering dependent.
-        # print(f"Particle {particle}:", wigner_angles[particle])
-        assert np.allclose(wigner_angles[particle].theta_rf, 0)
-        assert np.allclose(wigner_angles[particle].psi_rf, 0)
-
     hel1 = topo1.helicity_angles(momenta)
     hel2 = topo2.helicity_angles(momenta)
 
-    hel1_m_phi = topo1.helicity_angles(momenta, convention="minus_phi")
-    hel2_m_phi = topo2.helicity_angles(momenta, convention="minus_phi")
+    assert np.allclose(hel1[(2, 3)].theta_rf, (np.pi - hel2[(3, 2)].theta_rf))
 
-    assert np.allclose(hel1[(2, 3)].theta_rf, -(np.pi + hel2[(3, 2)].theta_rf))
-    print(hel1[(2, 3)].psi_rf - hel2[(3, 2)].psi_rf)
-    import matplotlib.pyplot as plt
-
-    plt.imshow(
-        hel1[(2, 3)].psi_rf - hel2[(3, 2)].psi_rf, extent=[-np.pi, np.pi, -np.pi, np.pi]
+    assert np.allclose(
+        hel1[(2, 3)].psi_rf - hel2[(3, 2)].psi_rf + wigner_angles[2].phi_rf, np.pi
     )
-    plt.savefig("temp.png")
-    # assert np.allclose(hel1[(2, 3)].psi_rf, hel2[(3, 2)].psi_rf - np.pi)
-    print(hel1_m_phi[(2, 3)], hel2_m_phi[(3, 2)])
 
     cfg.sorting = "value"
 

--- a/tests/test_particle2.py
+++ b/tests/test_particle2.py
@@ -17,15 +17,18 @@ def test_particle2():
         2: np.array([0.466794284860449, 0.0, 0.1935604618890383, 0.7064556158132482]),
         3: np.array([-0.466794284860449, 0.0, 0.2437988784199448, 0.5448069221267302]),
     }
-
-    rotation = LorentzTrafo(0, 0, 0, 1.0, 1.0, 1.0)
+    x, y = np.linspace(-np.pi + 1e-5, np.pi - 1e-5, 100), np.linspace(
+        -np.pi + 1e-5, np.pi - 1e-5, 100
+    )
+    X, Y = np.meshgrid(x, y)
+    rotation = LorentzTrafo(0, 0, 0, X, 1.0, Y)
     momenta = {i: rotation.matrix_4x4 @ p for i, p in momenta.items()}
     wigner_angles = topo1.relative_wigner_angles(topo2, momenta)
 
     for particle in [1, 2, 3]:
         # this will always be 0, since the chain of boosts and rotations into the particle i rest frame is order independent
         # this is, because the final state frame is determined by the boost axis from the second to last frame into the last frame. This is not ordering dependent.
-        print(f"Particle {particle}:", wigner_angles[particle])
+        # print(f"Particle {particle}:", wigner_angles[particle])
         assert np.allclose(wigner_angles[particle].theta_rf, 0)
         assert np.allclose(wigner_angles[particle].psi_rf, 0)
 
@@ -36,7 +39,14 @@ def test_particle2():
     hel2_m_phi = topo2.helicity_angles(momenta, convention="minus_phi")
 
     assert np.allclose(hel1[(2, 3)].theta_rf, -(np.pi + hel2[(3, 2)].theta_rf))
-    assert np.allclose(hel1[(2, 3)].psi_rf, hel2[(3, 2)].psi_rf - np.pi)
+    print(hel1[(2, 3)].psi_rf - hel2[(3, 2)].psi_rf)
+    import matplotlib.pyplot as plt
+
+    plt.imshow(
+        hel1[(2, 3)].psi_rf - hel2[(3, 2)].psi_rf, extent=[-np.pi, np.pi, -np.pi, np.pi]
+    )
+    plt.savefig("temp.png")
+    # assert np.allclose(hel1[(2, 3)].psi_rf, hel2[(3, 2)].psi_rf - np.pi)
     print(hel1_m_phi[(2, 3)], hel2_m_phi[(3, 2)])
 
     cfg.sorting = "value"


### PR DESCRIPTION
Redefine the boosts, such that they are depending on the particle ordering for the helicity conventions

R_2 = R_1 R(pi, pi) 
-> the Wigner rotations correct for the transformation of phi 

Also the helicity angles were given inverted up until now.
This mistake was not caught due to a faulty test only checking the cosine of the angle (copied from the test against dpd, where only cosine can be tested).
This will become v1.0.5