### PR TITLE
Treat massless particles by choosing the final state frame as the mother frame

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -16,7 +16,9 @@ jobs:
       - uses: actions/setup-python@v3
       - name: Install dependencies
         run: |
-          pip install sphinx sphinx_rtd_theme myst_parser sphinx-mdinclude && pip install . && pip uninstall -y decayangle
+          pip install sphinx sphinx_rtd_theme myst_parser sphinx-mdinclude
+          pip install --no-deps .
+          pip install networkx jax jaxlib numpy tqdm
       - name: Sphinx build
         run: |
           sphinx-apidoc -o docs/ src && sphinx-build docs _build

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -23,13 +23,13 @@ repos:
     rev: v4.0.0-alpha.8
     hooks:
       - id: prettier
-        exclude: "decayangle-rs/*"
+        exclude: "decayangle-rs/*|scripts/*"
 
   - repo: https://github.com/econchick/interrogate
     rev: 1.7.0
     hooks:
       - id: interrogate
-        exclude: "src/decayangle/__*|tests/*|src/decayangle/backend.py|decayangle-rs/*"
+        exclude: "src/decayangle/__*|tests/*|src/decayangle/backend.py|decayangle-rs/*|scripts/*"
         args: [--fail-under=80, --verbose]
 
   - repo: https://github.com/codespell-project/codespell

--- a/decayangle-rs/src/lib.rs
+++ b/decayangle-rs/src/lib.rs
@@ -6,7 +6,7 @@ mod topology;
 use std::collections::HashMap;
 use numpy::{IntoPyArray, PyReadonlyArray2, PyUntypedArrayMethods};
 use pyo3::prelude::*;
-use pyo3::types::{PyDict, PyTuple};
+use pyo3::types::{PyDict, PyTuple, PyList};
 
 use topology::{Node, Topology, Convention};
 
@@ -66,10 +66,24 @@ fn parse_momenta(py_momenta: &Bound<'_, PyDict>) -> PyResult<HashMap<i32, Vec<[f
     Ok(out)
 }
 
+/// Convert a Python list of ints to a Rust Vec<i32>.
+fn parse_massless(py_massless: &Bound<'_, PyAny>) -> PyResult<Vec<i32>> {
+    if py_massless.is_none() {
+        return Ok(vec![]);
+    }
+    let list = py_massless.downcast::<PyList>()
+        .map_err(|_| pyo3::exceptions::PyTypeError::new_err("massless must be a list of ints"))?;
+    let mut out = Vec::with_capacity(list.len());
+    for item in list.iter() {
+        out.push(item.extract::<i32>()?);
+    }
+    Ok(out)
+}
+
 // ── Public Python functions ───────────────────────────────────────────────────
 
 #[pyfunction]
-#[pyo3(signature = (topology_tuple, momenta, tol=1e-10, safety_checks=true, convention="helicity"))]
+#[pyo3(signature = (topology_tuple, momenta, tol=1e-10, safety_checks=true, convention="helicity", massless=None))]
 fn helicity_angles_rust<'py>(
     py: Python<'py>,
     topology_tuple: &Bound<'py, PyAny>,
@@ -77,15 +91,20 @@ fn helicity_angles_rust<'py>(
     tol: f64,
     safety_checks: bool,
     convention: &str,
+    massless: Option<&Bound<'py, PyAny>>,
 ) -> PyResult<Bound<'py, PyDict>> {
     let root_node = parse_node(topology_tuple)?;
     let topo = Topology::new(root_node);
     let rust_momenta = parse_momenta(momenta)?;
     let conv = Convention::from_str(convention)
         .map_err(|e| pyo3::exceptions::PyValueError::new_err(e))?;
+    let massless_ids = match massless {
+        Some(m) => parse_massless(m)?,
+        None => vec![],
+    };
 
     let angles = topo
-        .helicity_angles(&rust_momenta, tol, safety_checks, conv)
+        .helicity_angles(&rust_momenta, tol, safety_checks, conv, &massless_ids)
         .map_err(|e| {
             if e.contains("not at rest") {
                 pyo3::exceptions::PyValueError::new_err(e)
@@ -108,7 +127,7 @@ fn helicity_angles_rust<'py>(
 }
 
 #[pyfunction]
-#[pyo3(signature = (topology1_tuple, topology2_tuple, momenta, tol=1e-10, safety_checks=true, convention="helicity"))]
+#[pyo3(signature = (topology1_tuple, topology2_tuple, momenta, tol=1e-10, safety_checks=true, convention="helicity", massless=None))]
 fn wigner_angles_rust<'py>(
     py: Python<'py>,
     topology1_tuple: &Bound<'py, PyAny>,
@@ -117,6 +136,7 @@ fn wigner_angles_rust<'py>(
     tol: f64,
     safety_checks: bool,
     convention: &str,
+    massless: Option<&Bound<'py, PyAny>>,
 ) -> PyResult<Bound<'py, PyDict>> {
     let root1 = parse_node(topology1_tuple)?;
     let root2 = parse_node(topology2_tuple)?;
@@ -125,9 +145,13 @@ fn wigner_angles_rust<'py>(
     let rust_momenta = parse_momenta(momenta)?;
     let conv = Convention::from_str(convention)
         .map_err(|e| pyo3::exceptions::PyValueError::new_err(e))?;
+    let massless_ids = match massless {
+        Some(m) => parse_massless(m)?,
+        None => vec![],
+    };
 
     let angles = topo1
-        .relative_wigner_angles(&topo2, &rust_momenta, tol, safety_checks, conv)
+        .relative_wigner_angles(&topo2, &rust_momenta, tol, safety_checks, conv, &massless_ids)
         .map_err(|e| {
             if e.contains("not at rest") {
                 pyo3::exceptions::PyValueError::new_err(e)

--- a/decayangle-rs/src/topology.rs
+++ b/decayangle-rs/src/topology.rs
@@ -213,6 +213,25 @@ impl TrafoSoA {
             });
     }
 
+    /// inverse: result[i] = self[i]^{-1}
+    fn inverse(&self) -> TrafoSoA {
+        let n = self.n;
+        let mut m4 = vec![0.0f64; n * 16];
+        let mut m2 = vec![Complex64::new(0., 0.); n * 4];
+        m4.par_chunks_mut(16).zip(m2.par_chunks_mut(4))
+            .enumerate()
+            .for_each(|(i, (c4, c2))| {
+                let a4 = self.mat4(i).try_inverse().expect("non-invertible 4x4");
+                for row in 0..4 { for col in 0..4 {
+                    c4[row * 4 + col] = a4[(row, col)];
+                }}
+                let a2 = self.mat2(i).try_inverse().expect("non-invertible 2x2");
+                c2[0] = a2[(0,0)]; c2[1] = a2[(0,1)];
+                c2[2] = a2[(1,0)]; c2[3] = a2[(1,1)];
+            });
+        TrafoSoA { n, m4, m2 }
+    }
+
     /// Apply all 4×4 matrices to the corresponding event momenta.
     fn transform_momenta(&self, momenta: &HashMap<i32, Vec<[f64; 4]>>) -> HashMap<i32, Vec<[f64; 4]>> {
         momenta.iter().map(|(k, batch)| {
@@ -257,6 +276,26 @@ impl TrafoSoA {
             psis[i]   = psi_rf;
         }
         Ok((phis, thetas, psis))
+    }
+
+    // For massless particles the composed 4×4 is not a factorizable Lorentz boost,
+    // so decode Wigner angles directly from the SU(2) matrix, matching Python's
+    // decode_pure_rotation / wigner_angles path.
+    fn wigner_angles_su2_direct_batch(&self) -> (Vec<f64>, Vec<f64>, Vec<f64>) {
+        let n = self.n;
+        let mut phis   = vec![0.0f64; n];
+        let mut thetas = vec![0.0f64; n];
+        let mut psis   = vec![0.0f64; n];
+        phis.par_iter_mut().zip(thetas.par_iter_mut()).zip(psis.par_iter_mut())
+            .enumerate()
+            .for_each(|(i, ((phi, theta), psi))| {
+                let m2 = self.mat2(i);
+                let (phi_rf, theta_rf, psi_rf) = decode_su2_rotation(&m2);
+                *phi   = phi_rf;
+                *theta = theta_rf;
+                *psi   = psi_rf;
+            });
+        (phis, thetas, psis)
     }
 }
 
@@ -311,6 +350,11 @@ impl Topology {
     }
 
     /// Compute one step of the boost: node → target daughter, for a given convention.
+    ///
+    /// `momenta` must be in `node`'s rest frame. For massless targets the boost-to-rest is
+    /// replaced by a canonical (pure) boost to the total-momentum rest frame, computed
+    /// directly from the total 4-momentum as seen in the current node frame. The rotation
+    /// part (aligning with left daughter / flip) is applied identically to the massive case.
     fn boost_step(
         node: &Node,
         target: &Node,
@@ -318,6 +362,7 @@ impl Topology {
         tol: f64,
         safety_checks: bool,
         convention: Convention,
+        massless: &[i32],
     ) -> Result<TrafoSoA, String> {
         let n = momenta.values().next().map(|v| v.len()).unwrap_or(0);
 
@@ -341,6 +386,21 @@ impl Topology {
             }
         }
 
+        let target_is_massless = target.is_leaf() && {
+            if let Node::Leaf(id) = target { massless.contains(id) } else { false }
+        };
+
+        // For massless targets: sum all final-state momenta in the current node frame
+        // to get the total 4-momentum whose rest frame we boost to.
+        let total_mom: Vec<[f64; 4]> = if target_is_massless {
+            let batches: Vec<&Vec<[f64; 4]>> = momenta.values().collect();
+            (0..n).map(|i| {
+                batches.iter().fold([0.0; 4], |acc, b| add4(&acc, &b[i]))
+            }).collect()
+        } else {
+            vec![]
+        };
+
         let n_events = n;
         let mut m4 = vec![0.0f64; n_events * 16];
         let mut m2 = vec![Complex64::new(0., 0.); n_events * 4];
@@ -357,20 +417,41 @@ impl Topology {
             .enumerate()
             .for_each(|(i, (c4, c2))| {
                 let (minus_phi_rf, minus_theta_rf) = rotate_to_z_axis(&rotate_ref_mom[i]);
-                let xi = -rapidity(&target_mom[i]);
 
-                let bst4 = build_4_4(0., 0., xi, 0., 0., 0.);
-                let bst2 = build_2_2(0., 0., xi, 0., 0., 0.);
+                // Build the boost matrix: for massless targets use a canonical pure boost
+                // to the total-momentum rest frame; for massive targets use the standard
+                // z-boost to the target's rest frame.
+                let (bst4, bst2) = if target_is_massless {
+                    // Pure canonical boost to total-momentum rest frame:
+                    // rotate total_mom to z, boost along z, rotate back.
+                    let (tot_mphi, tot_mtheta) = rotate_to_z_axis(&total_mom[i]);
+                    let xi_tot = -rapidity(&total_mom[i]);
+                    let rot4 = build_4_4(0., 0., 0., 0., tot_mtheta, tot_mphi);
+                    let rot2 = build_2_2(0., 0., 0., 0., tot_mtheta, tot_mphi);
+                    let bz4  = build_4_4(0., 0., xi_tot, 0., 0., 0.);
+                    let bz2  = build_2_2(0., 0., xi_tot, 0., 0., 0.);
+                    let rot4_inv = rot4.try_inverse().expect("rotation invertible");
+                    let rot2_inv = rot2.try_inverse().expect("rotation invertible");
+                    (rot4_inv * bz4 * rot4, rot2_inv * bz2 * rot2)
+                } else {
+                    let xi = -rapidity(&target_mom[i]);
+                    (build_4_4(0., 0., xi, 0., 0., 0.), build_2_2(0., 0., xi, 0., 0., 0.))
+                };
 
                 let (r4, r2) = match convention {
                     Convention::Canonical => {
-                        // rot aligns target with z; result = rot^{-1} @ boost @ rot
-                        // no flip needed — canonical always acts on the specific target
-                        let rot4 = build_4_4(0., 0., 0., 0., minus_theta_rf, minus_phi_rf);
-                        let rot2 = build_2_2(0., 0., 0., 0., minus_theta_rf, minus_phi_rf);
-                        let rot4_inv = rot4.try_inverse().expect("rotation invertible");
-                        let rot2_inv = rot2.try_inverse().expect("rotation invertible");
-                        (rot4_inv * bst4 * rot4, rot2_inv * bst2 * rot2)
+                        if target_is_massless {
+                            // boost is already a pure canonical boost to total-mom rest frame;
+                            // return it directly (same as Python: return boost_to_root).
+                            (bst4, bst2)
+                        } else {
+                            // rot aligns target with z; result = rot^{-1} @ boost @ rot
+                            let rot4 = build_4_4(0., 0., 0., 0., minus_theta_rf, minus_phi_rf);
+                            let rot2 = build_2_2(0., 0., 0., 0., minus_theta_rf, minus_phi_rf);
+                            let rot4_inv = rot4.try_inverse().expect("rotation invertible");
+                            let rot2_inv = rot2.try_inverse().expect("rotation invertible");
+                            (rot4_inv * bst4 * rot4, rot2_inv * bst2 * rot2)
+                        }
                     }
                     Convention::Helicity => {
                         // rot aligns left daughter with z; result = boost @ [flip @] rot
@@ -416,6 +497,7 @@ impl Topology {
         tol: f64,
         safety_checks: bool,
         convention: Convention,
+        massless: &[i32],
     ) -> Result<TrafoSoA, String> {
         let path = self.path_to(target);
         let n = momenta.values().next().map(|v| v.len()).unwrap_or(0);
@@ -425,12 +507,12 @@ impl Topology {
         }
 
         let mut current_momenta = momenta.clone();
-        let first_step = Self::boost_step(path[0], path[1], &current_momenta, tol, safety_checks, convention)?;
+        let first_step = Self::boost_step(path[0], path[1], &current_momenta, tol, safety_checks, convention, massless)?;
         current_momenta = first_step.transform_momenta(&current_momenta);
         let mut composed = first_step;
 
         for i in 1..path.len() - 1 {
-            let step = Self::boost_step(path[i], path[i+1], &current_momenta, tol, safety_checks, convention)?;
+            let step = Self::boost_step(path[i], path[i+1], &current_momenta, tol, safety_checks, convention, massless)?;
             current_momenta = step.transform_momenta(&current_momenta);
             composed.left_compose_assign(&step);
         }
@@ -446,6 +528,7 @@ impl Topology {
         tol: f64,
         safety_checks: bool,
         convention: Convention,
+        massless: &[i32],
     ) -> Result<TrafoSoA, String> {
         let path = self.path_to(target);
         let n = momenta.values().next().map(|v| v.len()).unwrap_or(0);
@@ -458,7 +541,7 @@ impl Topology {
         let mut current_momenta = momenta.clone();
 
         for i in 0..path.len() - 1 {
-            let step = Self::boost_step(path[i], path[i+1], &current_momenta, tol, safety_checks, convention)?;
+            let step = Self::boost_step(path[i], path[i+1], &current_momenta, tol, safety_checks, convention, massless)?;
             current_momenta = step.transform_momenta(&current_momenta);
             all_steps.push(step);
         }
@@ -477,6 +560,7 @@ impl Topology {
         tol: f64,
         safety_checks: bool,
         convention: Convention,
+        massless: &[i32],
     ) -> Result<HashMap<(Vec<i32>, Vec<i32>), (Vec<f64>, Vec<f64>)>, String> {
         let n = momenta.values().next().map(|v| v.len()).unwrap_or(0);
         let mut result = HashMap::new();
@@ -488,7 +572,7 @@ impl Topology {
             let frame_momenta = if node.particles() == self.root.particles() {
                 momenta
             } else {
-                let trafos = self.boost_to_soa(node, momenta, tol, safety_checks, convention)?;
+                let trafos = self.boost_to_soa(node, momenta, tol, safety_checks, convention, massless)?;
                 frame_momenta_owned = trafos.transform_momenta(momenta);
                 &frame_momenta_owned
             };
@@ -514,6 +598,7 @@ impl Topology {
         tol: f64,
         safety_checks: bool,
         convention: Convention,
+        massless: &[i32],
     ) -> Result<HashMap<i32, (Vec<f64>, Vec<f64>, Vec<f64>)>, String> {
         let n = momenta.values().next().map(|v| v.len()).unwrap_or(0);
         let mut result = HashMap::new();
@@ -529,11 +614,18 @@ impl Topology {
                 continue;
             }
 
-            let boost1_inv = self.boost_to_inverse_soa(fs_node, momenta, tol, safety_checks, convention)?;
-            let boost2     = other.boost_to_soa(fs_node, momenta, tol, safety_checks, convention)?;
+            let boost1_inv = self.boost_to_inverse_soa(fs_node, momenta, tol, safety_checks, convention, massless)?;
+            let boost2     = other.boost_to_soa(fs_node, momenta, tol, safety_checks, convention, massless)?;
             let combined   = boost2.compose(&boost1_inv);
 
-            let (phis, thetas, psis) = combined.wigner_angles_batch(tol, safety_checks)?;
+            let (phis, thetas, psis) = if massless.contains(&particle) {
+                // Massless particle: the composed 4×4 is not a factorizable Lorentz boost,
+                // so decode Wigner angles directly from the SU(2) matrix (mirrors Python's
+                // decode_pure_rotation / wigner_angles path).
+                combined.wigner_angles_su2_direct_batch()
+            } else {
+                combined.wigner_angles_batch(tol, safety_checks)?
+            };
             result.insert(particle, (phis, thetas, psis));
         }
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,6 +54,7 @@ branch = true
 relative_files = true
 omit = [
     'tests/*',
+    'scripts/*',
 ]
 
 [tool.hatch.envs.test]

--- a/scripts/massless_limit_wigner.py
+++ b/scripts/massless_limit_wigner.py
@@ -203,14 +203,23 @@ print("Computing 5-body...")
 )
 
 
+# ── Helpers ───────────────────────────────────────────────────────────────────
+
+
+def topo_latex(topo):
+    """Convert a Topology repr to a LaTeX string."""
+    s = repr(topo).replace("Topology: ", "").replace("->", r"\to").replace(",", "")
+    return f"${s}$"
+
+
 # ── Plot ──────────────────────────────────────────────────────────────────────
 
 configs = [
     (
         3,
         M0_3,
-        tg3.topologies[0].tuple,
-        tg3.topologies[1].tuple,
+        tg3.topologies[0],
+        tg3.topologies[1],
         theta_3,
         pps_3,
         theta_3_exact,
@@ -220,8 +229,8 @@ configs = [
     (
         4,
         M0_4,
-        tg4.topologies[3].tuple,
-        tg4.topologies[6].tuple,
+        tg4.topologies[3],
+        tg4.topologies[6],
         theta_4,
         pps_4,
         theta_4_exact,
@@ -231,8 +240,8 @@ configs = [
     (
         5,
         M0_5,
-        tg5.topologies[18].tuple,
-        tg5.topologies[30].tuple,
+        tg5.topologies[18],
+        tg5.topologies[30],
         theta_5,
         pps_5,
         theta_5_exact,
@@ -242,7 +251,7 @@ configs = [
 ]
 
 for n, m0, ta, tb, thetas, pps, theta_exact, pps_exact, tag in configs:
-    title = f"{n}-body: {ta} vs {tb}"
+    title = f"{topo_latex(ta)} vs {topo_latex(tb)}"
 
     for data, exact, ylabel, subtag in [
         (

--- a/scripts/massless_limit_wigner.py
+++ b/scripts/massless_limit_wigner.py
@@ -121,7 +121,17 @@ def scan_wigner_angles(
             float(np.array(w.phi_rf).flat[0]) + float(np.array(w.psi_rf).flat[0])
         )
 
-    return np.array(thetas), np.array(phi_plus_psis)
+    # Exact massless limit: m=0, massless flag set
+    momenta = add_batch_dim(make_momenta_fn(0.0))
+    momenta_rest = topo_a.to_rest_frame(momenta)
+    wa = topo_a.relative_wigner_angles(
+        topo_b, momenta_rest, convention=convention, massless=[massless_particle]
+    )
+    w = wa[massless_particle]
+    theta_exact = float(np.array(w.theta_rf).flat[0])
+    pps_exact = float(np.array(w.phi_rf).flat[0]) + float(np.array(w.psi_rf).flat[0])
+
+    return np.array(thetas), np.array(phi_plus_psis), theta_exact, pps_exact
 
 
 def scan_all_conventions(
@@ -141,7 +151,7 @@ def scan_all_conventions(
         mass_values,
         convention="helicity",
     )
-    return (helicity,)
+    return (helicity,)  # tuple of (thetas, pps, theta_exact, pps_exact)
 
 
 # ── Setup decays ──────────────────────────────────────────────────────────────
@@ -178,17 +188,17 @@ def make5(m1):
 # ── Compute ───────────────────────────────────────────────────────────────────
 
 print("Computing 3-body...")
-((theta_3, pps_3),) = scan_all_conventions(
+((theta_3, pps_3, theta_3_exact, pps_3_exact),) = scan_all_conventions(
     make3, tg3, 0, 1, massless_particle=1, mass_values=mass_values
 )
 
 print("Computing 4-body...")
-((theta_4, pps_4),) = scan_all_conventions(
+((theta_4, pps_4, theta_4_exact, pps_4_exact),) = scan_all_conventions(
     make4, tg4, 3, 6, massless_particle=1, mass_values=mass_values
 )
 
 print("Computing 5-body...")
-((theta_5, pps_5),) = scan_all_conventions(
+((theta_5, pps_5, theta_5_exact, pps_5_exact),) = scan_all_conventions(
     make5, tg5, 18, 30, massless_particle=1, mass_values=mass_values
 )
 
@@ -203,6 +213,8 @@ configs = [
         tg3.topologies[1].tuple,
         theta_3,
         pps_3,
+        theta_3_exact,
+        pps_3_exact,
         "3body",
     ),
     (
@@ -212,6 +224,8 @@ configs = [
         tg4.topologies[6].tuple,
         theta_4,
         pps_4,
+        theta_4_exact,
+        pps_4_exact,
         "4body",
     ),
     (
@@ -221,25 +235,34 @@ configs = [
         tg5.topologies[30].tuple,
         theta_5,
         pps_5,
+        theta_5_exact,
+        pps_5_exact,
         "5body",
     ),
 ]
 
-for n, m0, ta, tb, thetas, pps, tag in configs:
+for n, m0, ta, tb, thetas, pps, theta_exact, pps_exact, tag in configs:
     title = f"{n}-body: {ta} vs {tb}"
 
-    for data, ylabel, subtag in [
-        (thetas / np.pi, r"$\theta_{\rm Wigner}$ $[\pi]$", "theta"),
-        (pps / np.pi, r"$(\phi + \psi)$ $[\pi]$", "phi_plus_psi"),
+    for data, exact, ylabel, subtag in [
+        (
+            thetas / np.pi,
+            theta_exact / np.pi,
+            r"$\theta_{\rm Wigner}$ $[\pi]$",
+            "theta",
+        ),
+        (pps / np.pi, pps_exact / np.pi, r"$(\phi + \psi)$ $[\pi]$", "phi_plus_psi"),
     ]:
         fig, ax = plt.subplots(figsize=(6, 4))
         ax.plot(mass_values, data, "o-", ms=3, lw=1)
+        ax.axhline(exact, color="C1", lw=1.5, ls="--", label=r"$m_1 = 0$ (exact)")
         ax.set_xscale("log")
         ax.invert_xaxis()
         ax.set_xlabel("$m_1$ [arbitrary units]", fontsize=14)
         ax.set_ylabel(ylabel, fontsize=14)
         ax.set_title(title, fontsize=10)
-        ax.axhline(0, color="k", lw=0.5, ls="--")
+        ax.axhline(0, color="k", lw=0.5, ls=":")
+        ax.legend(fontsize=11)
         ax.grid(True, alpha=0.3)
         fig.tight_layout()
         path = f"scripts/massless_limit_wigner_{tag}_{subtag}.png"

--- a/scripts/massless_limit_wigner.py
+++ b/scripts/massless_limit_wigner.py
@@ -1,0 +1,248 @@
+"""
+Plot relative Wigner theta angle vs particle mass approaching zero,
+for 3-, 4-, and 5-body decays. One kinematic point each, two topology
+pairs compared, particle 1 driven massless.
+
+Usage:
+    python scripts/massless_limit_wigner.py
+"""
+
+import numpy as np
+import matplotlib.pyplot as plt
+from decayangle.decay_topology import TopologyCollection
+from decayangle.config import config as cfg
+
+cfg.sorting = "off"
+cfg.use_rust = False
+
+
+# ── Kinematics helpers ────────────────────────────────────────────────────────
+
+
+def _isotropic_unit(rng):
+    phi = rng.uniform(0, 2 * np.pi)
+    cos_th = rng.uniform(-1, 1)
+    sin_th = np.sqrt(1 - cos_th**2)
+    return np.array([sin_th * np.cos(phi), sin_th * np.sin(phi), cos_th])
+
+
+def make_3body(m0, m1, m2, m3, seed=0):
+    """One kinematic point for a 3-body decay in the mother rest frame."""
+    rng = np.random.default_rng(seed)
+    p1_mag = rng.uniform(0.05, 0.35) * m0
+    p2_mag = rng.uniform(0.05, 0.35) * m0
+    p1 = p1_mag * _isotropic_unit(rng)
+    p2 = p2_mag * _isotropic_unit(rng)
+    p3 = -(p1 + p2)
+    E1 = np.sqrt(m1**2 + np.dot(p1, p1))
+    E2 = np.sqrt(m2**2 + np.dot(p2, p2))
+    E3 = np.sqrt(m3**2 + np.dot(p3, p3))
+    return {
+        1: np.array([*p1, E1]),
+        2: np.array([*p2, E2]),
+        3: np.array([*p3, E3]),
+    }
+
+
+def make_4body(m0, m1, m2, m3, m4, seed=0):
+    """One kinematic point for a 4-body decay in the mother rest frame."""
+    rng = np.random.default_rng(seed)
+    p1_mag = rng.uniform(0.05, 0.25) * m0
+    p2_mag = rng.uniform(0.05, 0.25) * m0
+    p3_mag = rng.uniform(0.05, 0.25) * m0
+    p1 = p1_mag * _isotropic_unit(rng)
+    p2 = p2_mag * _isotropic_unit(rng)
+    p3 = p3_mag * _isotropic_unit(rng)
+    p4 = -(p1 + p2 + p3)
+    E1 = np.sqrt(m1**2 + np.dot(p1, p1))
+    E2 = np.sqrt(m2**2 + np.dot(p2, p2))
+    E3 = np.sqrt(m3**2 + np.dot(p3, p3))
+    E4 = np.sqrt(m4**2 + np.dot(p4, p4))
+    return {
+        1: np.array([*p1, E1]),
+        2: np.array([*p2, E2]),
+        3: np.array([*p3, E3]),
+        4: np.array([*p4, E4]),
+    }
+
+
+def make_5body(m0, m1, m2, m3, m4, m5, seed=0):
+    """One kinematic point for a 5-body decay in the mother rest frame."""
+    rng = np.random.default_rng(seed)
+    mags = [rng.uniform(0.05, 0.2) * m0 for _ in range(4)]
+    ps = [mag * _isotropic_unit(rng) for mag in mags]
+    p5 = -sum(ps)
+    masses = [m1, m2, m3, m4, m5]
+    pvecs = ps + [p5]
+    return {
+        i + 1: np.array([*p, np.sqrt(m**2 + np.dot(p, p))])
+        for i, (p, m) in enumerate(zip(pvecs, masses))
+    }
+
+
+def add_batch_dim(momenta):
+    """Add a batch dimension so momenta have shape (1, 4)."""
+    return {k: v[np.newaxis, :] for k, v in momenta.items()}
+
+
+# ── Wigner theta scan ─────────────────────────────────────────────────────────
+
+
+def scan_wigner_angles(
+    make_momenta_fn,
+    topo_collection,
+    topo_idx_a,
+    topo_idx_b,
+    massless_particle,
+    mass_values,
+    convention="helicity",
+):
+    """
+    For each value in mass_values (applied to massless_particle), compute the
+    relative Wigner angles between topo_idx_a and topo_idx_b.
+    Returns (thetas, phi_plus_psi) arrays.
+    """
+    thetas = []
+    phi_plus_psis = []
+    topos = topo_collection.topologies
+    topo_a = topos[topo_idx_a]
+    topo_b = topos[topo_idx_b]
+
+    for m in mass_values:
+        momenta = add_batch_dim(make_momenta_fn(m))
+        momenta_rest = topo_a.to_rest_frame(momenta)
+        massless = [massless_particle] if m < 1e-3 else []
+        wa = topo_a.relative_wigner_angles(
+            topo_b, momenta_rest, convention=convention, massless=massless
+        )
+        w = wa[massless_particle]
+        thetas.append(float(np.array(w.theta_rf).flat[0]))
+        phi_plus_psis.append(
+            float(np.array(w.phi_rf).flat[0]) + float(np.array(w.psi_rf).flat[0])
+        )
+
+    return np.array(thetas), np.array(phi_plus_psis)
+
+
+def scan_all_conventions(
+    make_momenta_fn,
+    topo_collection,
+    topo_idx_a,
+    topo_idx_b,
+    massless_particle,
+    mass_values,
+):
+    helicity = scan_wigner_angles(
+        make_momenta_fn,
+        topo_collection,
+        topo_idx_a,
+        topo_idx_b,
+        massless_particle,
+        mass_values,
+        convention="helicity",
+    )
+    return (helicity,)
+
+
+# ── Setup decays ──────────────────────────────────────────────────────────────
+
+M0_3 = 5.0
+M0_4 = 6.0
+M0_5 = 7.0
+
+# Masses for non-scanned particles
+M2_3, M3_3 = 0.5, 1.0
+M2_4, M3_4, M4_4 = 0.5, 0.8, 1.0
+M2_5, M3_5, M4_5, M5_5 = 0.4, 0.6, 0.8, 1.0
+
+# Mass range for particle 1 (driven toward zero), log-spaced for uniform density
+mass_values = np.logspace(0, -5, 100)
+
+tg3 = TopologyCollection(0, [1, 2, 3])
+tg4 = TopologyCollection(0, [1, 2, 3, 4])
+tg5 = TopologyCollection(0, [1, 2, 3, 4, 5])
+
+
+def make3(m1):
+    return make_3body(M0_3, m1, M2_3, M3_3)
+
+
+def make4(m1):
+    return make_4body(M0_4, m1, M2_4, M3_4, M4_4)
+
+
+def make5(m1):
+    return make_5body(M0_5, m1, M2_5, M3_5, M4_5, M5_5)
+
+
+# ── Compute ───────────────────────────────────────────────────────────────────
+
+print("Computing 3-body...")
+((theta_3, pps_3),) = scan_all_conventions(
+    make3, tg3, 0, 1, massless_particle=1, mass_values=mass_values
+)
+
+print("Computing 4-body...")
+((theta_4, pps_4),) = scan_all_conventions(
+    make4, tg4, 3, 6, massless_particle=1, mass_values=mass_values
+)
+
+print("Computing 5-body...")
+((theta_5, pps_5),) = scan_all_conventions(
+    make5, tg5, 18, 30, massless_particle=1, mass_values=mass_values
+)
+
+
+# ── Plot ──────────────────────────────────────────────────────────────────────
+
+configs = [
+    (
+        3,
+        M0_3,
+        tg3.topologies[0].tuple,
+        tg3.topologies[1].tuple,
+        theta_3,
+        pps_3,
+        "3body",
+    ),
+    (
+        4,
+        M0_4,
+        tg4.topologies[3].tuple,
+        tg4.topologies[6].tuple,
+        theta_4,
+        pps_4,
+        "4body",
+    ),
+    (
+        5,
+        M0_5,
+        tg5.topologies[18].tuple,
+        tg5.topologies[30].tuple,
+        theta_5,
+        pps_5,
+        "5body",
+    ),
+]
+
+for n, m0, ta, tb, thetas, pps, tag in configs:
+    title = f"{n}-body: {ta} vs {tb}"
+
+    for data, ylabel, subtag in [
+        (thetas / np.pi, r"$\theta_{\rm Wigner}$ $[\pi]$", "theta"),
+        (pps / np.pi, r"$(\phi + \psi)$ $[\pi]$", "phi_plus_psi"),
+    ]:
+        fig, ax = plt.subplots(figsize=(6, 4))
+        ax.plot(mass_values, data, "o-", ms=3, lw=1)
+        ax.set_xscale("log")
+        ax.invert_xaxis()
+        ax.set_xlabel("$m_1$ [arbitrary units]", fontsize=14)
+        ax.set_ylabel(ylabel, fontsize=14)
+        ax.set_title(title, fontsize=10)
+        ax.axhline(0, color="k", lw=0.5, ls="--")
+        ax.grid(True, alpha=0.3)
+        fig.tight_layout()
+        path = f"scripts/massless_limit_wigner_{tag}_{subtag}.png"
+        fig.savefig(path, dpi=150)
+        print(f"Saved {path}")
+        plt.show()

--- a/src/decayangle/decay_topology.py
+++ b/src/decayangle/decay_topology.py
@@ -323,7 +323,6 @@ class Node:
             )
         target = Node.get_node(target)
         zero = cb.zeros_like(akm.time_component(self.momentum(momenta)))
-        one = cb.ones_like(zero)
         if self.value == target.value:
             return LorentzTrafo(zero, zero, zero, zero, zero, zero)
 
@@ -334,6 +333,7 @@ class Node:
 
         # boost to the rest frame of the target
         xi = -akm.rapidity(target.momentum(momenta))
+        xi = cb.where(cb.isfinite(xi), xi, zero)
         boost = LorentzTrafo(zero, zero, xi, zero, zero, zero)
 
         if convention == "canonical":

--- a/src/decayangle/decay_topology.py
+++ b/src/decayangle/decay_topology.py
@@ -339,9 +339,6 @@ class Node:
                 f"Target node {target} is not a direct daughter of this node {self}"
             )
 
-        # boost to the rest frame of the target
-        xi = -akm.rapidity(target.momentum(momenta))
-        boost = LorentzTrafo(zero, zero, xi, zero, zero, zero)
         masses = cb.nan_to_num(akm.mass(target.momentum(momenta)), nan=0)
         target_is_massless = (massless is not None) and (target.value in massless)
         if cb.all(masses < 1e-6) and not target_is_massless:
@@ -361,6 +358,10 @@ class Node:
             boost = boost_to_root
             if convention == "canonical":
                 return boost
+        else:
+            # boost to the rest frame of the target (only after massless check)
+            xi = -akm.rapidity(target.momentum(momenta))
+            boost = LorentzTrafo(zero, zero, xi, zero, zero, zero)
 
         if convention == "canonical":
             rotation, minus_theta_rf, minus_psi_rf = self.rotate_to(

--- a/src/decayangle/decay_topology.py
+++ b/src/decayangle/decay_topology.py
@@ -349,6 +349,8 @@ class Node:
                     self.root(), momenta, convention="canonical"
                 )  # canonical convention is a pure boost
             boost = boost_to_root
+            if convention == "canonical":
+                return boost
 
         if convention == "canonical":
             rotation, minus_theta_rf, minus_psi_rf = self.rotate_to(

--- a/src/decayangle/decay_topology.py
+++ b/src/decayangle/decay_topology.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 from typing import List, Tuple, Union, Any, Dict, Optional, Generator, Callable, Literal
 from collections import namedtuple
+import warnings
 import numpy as np
 from jax import numpy as jnp
 import networkx as nx
@@ -298,6 +299,7 @@ class Node:
         momenta: Dict[str, Union[np.array, jnp.array]],
         tol: Optional[float] = None,
         convention: Literal["helicity", "minus_phi", "canonical"] = "helicity",
+        massless: Optional[List[int]] = None,
     ) -> LorentzTrafo:
         """Get the boost from this node to a target node
         The momenta dictionary will define the initial configuration.
@@ -311,6 +313,7 @@ class Node:
                 helicity: we just rotate to be aligned with the target and boost
                 minus_phi: we rotate to be aligned, boost and then roate the azimutal angle (phi or psi) back
                 canonical: We rotate, boost and rotate back. Thus the action is a pure boost
+            massless (Optional[List[int]], optional): list of final-state particle IDs that are massless. Defaults to None.
         """
         if tol is None:
             tol = cfg.gamma_tolerance
@@ -340,13 +343,20 @@ class Node:
         xi = -akm.rapidity(target.momentum(momenta))
         boost = LorentzTrafo(zero, zero, xi, zero, zero, zero)
         masses = cb.nan_to_num(akm.mass(target.momentum(momenta)), nan=0)
-        if cb.all(masses < 1e-6):
+        target_is_massless = (massless is not None) and (target.value in massless)
+        if cb.all(masses < 1e-6) and not target_is_massless:
+            warnings.warn(
+                f"Particle {target.value} appears massless (mass < 1e-6) but was not declared in the `massless` list. "
+                "Pass massless=[...] to helicity_angles or relative_wigner_angles to apply the correct massless procedure.",
+                stacklevel=4,
+            )
+        if target_is_massless:
             target.parent = self
             if self.root() == self:
                 boost_to_root = LorentzTrafo(zero, zero, zero, zero, zero, zero)
             else:
                 boost_to_root = self.boost(
-                    self.root(), momenta, convention="canonical"
+                    self.root(), momenta, convention="canonical", massless=massless
                 )  # canonical convention is a pure boost
             boost = boost_to_root
             if convention == "canonical":
@@ -685,6 +695,7 @@ class Topology:
         momenta: Dict[str, Union[np.array, jnp.array]],
         tol: Optional[float] = None,
         convention: Literal["helicity", "minus_phi", "canonical"] = "helicity",
+        massless: Optional[List[int]] = None,
     ) -> Dict[Tuple[Union[tuple, int], Union[tuple, int]], HelicityAngles]:
         """
         Get a tree with the helicity angles for every internal node
@@ -697,7 +708,8 @@ class Topology:
                 helicity: we just rotate to be aligned with the target and boost
                 minus_phi: we rotate to be aligned, boost and then roate the azimutal angle (phi or psi) back
                 canonical: We rotate, boost and rotate back. Thus the action is a pure boost
-
+            massless(Optional[List[int]]): list of final-state particle IDs to treat as massless.
+            Defaults to None.
 
         Returns:
             Helicity angles for the final state particles
@@ -724,6 +736,7 @@ class Topology:
                 tol=tol if tol is not None else cfg.gamma_tolerance,
                 safety_checks=cfg.numerical_safety_checks,
                 convention=convention,
+                massless=massless if massless is not None else [],
             )
 
             ordering_fn = self.ordering_function
@@ -748,7 +761,7 @@ class Topology:
                 if node != self.root:
                     # TODO: this is a slow, but clean approach, where we only arrive in internal node frames vial the boost method. Maybe we could speed this up by not boosting from the root all the time
                     boost_to_node = self.boost(
-                        node, momenta, tol=tol, convention=convention
+                        node, momenta, tol=tol, convention=convention, massless=massless
                     )
                     momenta_in_node_frame = self.root.transform(boost_to_node, momenta)
                 else:
@@ -766,6 +779,7 @@ class Topology:
         inverse: bool = False,
         tol: Optional[float] = None,
         convention: Literal["helicity", "minus_phi", "canonical"] = "helicity",
+        massless: Optional[List[int]] = None,
     ) -> LorentzTrafo:
         """
         Get the boost from the root node to a target node.
@@ -776,6 +790,7 @@ class Topology:
             inverse: If True, return the inverse of the boost
             tol: Tolerance for the gamma check. Defaults to the value in the config.
             convention: The convention to use for the boost. Defaults to "helicity".
+            massless: List of final-state particle IDs that are massless. Defaults to None.
 
         Returns:
             Boost from the root node to the target node
@@ -784,13 +799,21 @@ class Topology:
         target = Node.get_node(target)
         path, node_dict = self.path_to(target)
         trafo = self.root.boost(
-            node_dict[path[0]], momenta, tol=tol, convention=convention
+            node_dict[path[0]],
+            momenta,
+            tol=tol,
+            convention=convention,
+            massless=massless,
         )
         momenta = self.root.transform(trafo, momenta)
         trafos = [trafo]
         for i in range(1, len(path)):
             boost = node_dict[path[i - 1]].boost(
-                node_dict[path[i]], momenta, tol=tol, convention=convention
+                node_dict[path[i]],
+                momenta,
+                tol=tol,
+                convention=convention,
+                massless=massless,
             )
             momenta = node_dict[path[i - 1]].transform(boost, momenta)
             trafo = boost @ trafo
@@ -810,6 +833,7 @@ class Topology:
         momenta: Dict[str, Union[np.array, jnp.array]],
         tol: Optional[float] = None,
         convention: Literal["helicity", "minus_phi", "canonical"] = "helicity",
+        massless: Optional[List[int]] = None,
     ) -> LorentzTrafo:
         """Get the relative Wigner angles between two topologies
 
@@ -818,6 +842,7 @@ class Topology:
             target: Node to compare to
             momenta: Dictionary of momenta for the final state particles
             tol: Tolerance for the gamma check. Defaults to the value in the config.
+            massless: List of final-state particle IDs that are massless. Defaults to None.
 
         Returns:
             The rotation between the two rest frames for the target node, one arrives at by boosting from the mother rest frame to the target rest frame as described by the two topologies
@@ -831,9 +856,16 @@ class Topology:
         target = Node.get_node(target)
         # invert self, since this final state is seen as the reference
         boost1_inv = self.boost(
-            target, momenta, tol=tol, convention=convention, inverse=True
+            target,
+            momenta,
+            tol=tol,
+            convention=convention,
+            inverse=True,
+            massless=massless,
         )
-        boost2 = other.boost(target, momenta, tol=tol, convention=convention)
+        boost2 = other.boost(
+            target, momenta, tol=tol, convention=convention, massless=massless
+        )
         return boost2 @ boost1_inv
 
     def relative_wigner_angles(
@@ -842,6 +874,7 @@ class Topology:
         momenta: Dict[str, Union[np.array, jnp.array]],
         tol: Optional[float] = None,
         convention: Literal["helicity", "minus_phi", "canonical"] = "helicity",
+        massless: Optional[List[int]] = None,
     ) -> Dict[int, Tuple[Union[jnp.ndarray, np.array], Union[jnp.ndarray, np.array]]]:
         """Get the relative Wigner angles between two topologies
 
@@ -850,6 +883,7 @@ class Topology:
             target: Node to compare to
             momenta: Dictionary of momenta for the final state particles
             tol: Tolerance for the gamma check. Defaults to the value in the config.
+            massless: List of final-state particle IDs to treat as massless. Defaults to None.
 
         Returns:
             Dict of the relative Wigner angles with the final state node as key
@@ -876,6 +910,7 @@ class Topology:
                 tol=tol if tol is not None else cfg.gamma_tolerance,
                 safety_checks=cfg.numerical_safety_checks,
                 convention=convention,
+                massless=massless if massless is not None else [],
             )
             return {
                 k: WignerAngles(
@@ -892,7 +927,12 @@ class Topology:
 
         return {
             target.value: self.rotate_between_topologies(
-                other, target, momenta, tol=tol, convention=convention
+                other,
+                target,
+                momenta,
+                tol=tol,
+                convention=convention,
+                massless=massless,
             ).wigner_angles()
             for target in self.final_state_nodes
         }

--- a/src/decayangle/lorentz.py
+++ b/src/decayangle/lorentz.py
@@ -140,6 +140,17 @@ class LorentzTrafo:
 
         raise ValueError(f"Invalid method for decoding: {method}")
 
+    def decode_pure_rotation(self) -> Tuple[Union[np.array, jnp.array]]:
+        """Decode the parameters of the Lorentz transformation
+
+        Returns:
+            Tuple[Union[np.array, jnp.array]]: The parameters of the Lorentz transformation
+        """
+        phi_rf_no_boost, theta_rf_no_boost, psi_rf_no_boost = decode_su2_rotation(
+            self.matrix_2x2
+        )
+        return phi_rf_no_boost, theta_rf_no_boost, psi_rf_no_boost
+
     def __repr__(self) -> str:
         """
         String representation of the Lorentz transformation. It shows the SU(2) and O(3,1) matrices.
@@ -175,7 +186,8 @@ class LorentzTrafo:
         Returns:
             Tuple[Union[np.array, jnp.array]]: the angles of the rotation in the frame before the boost
         """
-        _, _, _, phi_rf, theta_rf, psi_rf = self.decode(
-            two_pi_aware=True, method=method
-        )
+        # _, _, _, phi_rf, theta_rf, psi_rf = self.decode(
+        #     two_pi_aware=True, method=method
+        # )
+        phi_rf, theta_rf, psi_rf = self.decode_pure_rotation()
         return WignerAngles(phi_rf, theta_rf, psi_rf)

--- a/tests/rust_equivalence/test_massless_rust.py
+++ b/tests/rust_equivalence/test_massless_rust.py
@@ -1,0 +1,166 @@
+"""
+Comprehensive Python vs Rust comparison for massless particles.
+
+Compares helicity_angles and relative_wigner_angles for all topology pairs
+and all conventions, with particle 2 declared massless. Collects all failures
+and reports them together rather than stopping at the first mismatch.
+"""
+
+import numpy as np
+import pytest
+from itertools import product
+
+from decayangle.decay_topology import TopologyCollection, Topology
+from decayangle.config import config as cfg
+
+from .conftest import skip_no_rust
+
+CONVENTIONS = ["helicity", "minus_phi"]
+ATOL = 1e-8
+
+
+def _make_massless_momenta(n=500, seed=7):
+    """
+    Generate n 3-body events with particle 2 exactly massless (E = |p|).
+    Momenta are in the approximate mother rest frame.
+    """
+    rng = np.random.default_rng(seed)
+    # particle 1 — massive
+    p1 = np.column_stack(
+        [
+            rng.uniform(-0.4, 0.4, n),
+            rng.uniform(-0.4, 0.4, n),
+            rng.uniform(-0.9, 0.9, n),
+            np.ones(n),
+        ]
+    )
+    p1[:, 3] = np.sqrt(0.04 + np.sum(p1[:, :3] ** 2, axis=1))  # m1 = 0.2
+
+    # particle 2 — massless: pick a random direction, set E = |p|
+    phi2 = rng.uniform(0, 2 * np.pi, n)
+    theta2 = np.arccos(rng.uniform(-1, 1, n))
+    pmag2 = rng.uniform(0.1, 0.8, n)
+    p2 = np.column_stack(
+        [
+            pmag2 * np.sin(theta2) * np.cos(phi2),
+            pmag2 * np.sin(theta2) * np.sin(phi2),
+            pmag2 * np.cos(theta2),
+            pmag2,  # E = |p| for massless
+        ]
+    )
+
+    # particle 3 — momentum conservation, energy from m3 = 0.5
+    p3_spatial = -p1[:, :3] - p2[:, :3]
+    p3 = np.column_stack(
+        [
+            p3_spatial,
+            np.sqrt(0.25 + np.sum(p3_spatial**2, axis=1)),  # m3 = 0.5
+        ]
+    )
+
+    return {1: p1, 2: p2, 3: p3}
+
+
+def _angles_close(a, b):
+    """Check two angle arrays agree via sin/cos (handles ±2π)."""
+    return np.allclose(np.sin(a), np.sin(b), atol=ATOL) and np.allclose(
+        np.cos(a), np.cos(b), atol=ATOL
+    )
+
+
+def _max_angle_diff(a, b):
+    ds = np.max(np.abs(np.sin(np.asarray(a)) - np.sin(np.asarray(b))))
+    dc = np.max(np.abs(np.cos(np.asarray(a)) - np.cos(np.asarray(b))))
+    return max(ds, dc)
+
+
+@skip_no_rust
+def test_massless_rust_comprehensive():
+    raw_momenta = _make_massless_momenta()
+    tg = TopologyCollection(0, [1, 2, 3])
+    topologies = tg.topologies  # 3 topologies for 3-body decay
+
+    failures = []
+
+    for ref_idx, ref_topo in enumerate(topologies):
+        momenta = ref_topo.to_rest_frame(raw_momenta)
+
+        # ── helicity_angles ───────────────────────────────────────────────────
+        for topo_idx, topo in enumerate(topologies):
+            for convention in CONVENTIONS:
+                cfg.use_rust = False
+                py_ha = topo.helicity_angles(
+                    momenta, convention=convention, massless=[2]
+                )
+                cfg.use_rust = True
+                rs_ha = topo.helicity_angles(
+                    momenta, convention=convention, massless=[2]
+                )
+
+                for (isobar, bachelor), py_angles in py_ha.items():
+                    rs_angles = rs_ha.get((isobar, bachelor))
+                    if rs_angles is None:
+                        failures.append(
+                            f"helicity_angles: ref={ref_idx} topo={topo_idx} conv={convention} "
+                            f"key ({isobar},{bachelor}) missing in Rust output"
+                        )
+                        continue
+                    for angle_name, py_val, rs_val in [
+                        ("phi", py_angles.phi_rf, rs_angles.phi_rf),
+                        ("theta", py_angles.theta_rf, rs_angles.theta_rf),
+                    ]:
+                        if not _angles_close(py_val, rs_val):
+                            diff = _max_angle_diff(py_val, rs_val)
+                            failures.append(
+                                f"helicity_angles: ref={ref_idx} topo={topo_idx} "
+                                f"conv={convention} key=({isobar},{bachelor}) "
+                                f"angle={angle_name} max_diff={diff:.2e}"
+                            )
+
+        # ── relative_wigner_angles ────────────────────────────────────────────
+        for i, j in product(range(len(topologies)), repeat=2):
+            topo_i = topologies[i]
+            topo_j = topologies[j]
+            for convention in CONVENTIONS:
+                cfg.use_rust = False
+                py_wa = topo_i.relative_wigner_angles(
+                    topo_j, momenta, convention=convention, massless=[2]
+                )
+                cfg.use_rust = True
+                rs_wa = topo_i.relative_wigner_angles(
+                    topo_j, momenta, convention=convention, massless=[2]
+                )
+
+                for particle in py_wa:
+                    py_w = py_wa[particle]
+                    rs_w = rs_wa.get(particle)
+                    if rs_w is None:
+                        failures.append(
+                            f"wigner: ref={ref_idx} ({i},{j}) conv={convention} "
+                            f"particle={particle} missing in Rust output"
+                        )
+                        continue
+
+                    # Skip massless particle itself — angles are numerically undefined
+                    if particle == 2:
+                        continue
+
+                    for angle_name, py_val, rs_val in [
+                        ("phi_rf", py_w.phi_rf, rs_w.phi_rf),
+                        ("theta_rf", py_w.theta_rf, rs_w.theta_rf),
+                        ("psi_rf", py_w.psi_rf, rs_w.psi_rf),
+                    ]:
+                        if not _angles_close(py_val, rs_val):
+                            diff = _max_angle_diff(py_val, rs_val)
+                            failures.append(
+                                f"wigner: ref={ref_idx} ({i},{j}) conv={convention} "
+                                f"particle={particle} angle={angle_name} max_diff={diff:.2e}"
+                            )
+
+    cfg.use_rust = False  # restore
+
+    if failures:
+        report = f"{len(failures)} failure(s):\n" + "\n".join(
+            f"  {f}" for f in failures
+        )
+        pytest.fail(report)

--- a/tests/test_equivalence.py
+++ b/tests/test_equivalence.py
@@ -7,6 +7,7 @@ from functools import lru_cache
 from decayangle.config import config as cfg
 from decayangle.lorentz import LorentzTrafo
 from decayangle.decay_topology import Topology, TopologyCollection
+import decayangle.kinematics as akm
 
 subprocess.check_call([sys.executable, "-m", "pip", "install", "sympy"])
 from sympy import Rational
@@ -50,10 +51,10 @@ def make_four_vectors(phi_rf, theta_rf, psi_rf):
     # Given values
     # Lc -> p K pi
     m0 = 6.32397
-    m12 = 9.55283383**0.5
+    m12 = 8.55283383**0.5
     m23 = 26.57159046**0.5
     m13 = 17.86811729**0.5
-    m1, m2, m3 = 1, 2, 3
+    m1, m2, m3 = 0, 2, 3
     # Squared masses
     m0sq, m1sq, m2sq, m3sq, m12sq, m23sq = [x**2 for x in [m0, m1, m2, m3, m12, m23]]
 
@@ -506,6 +507,8 @@ def test_equivalence(resonance_lineshapes_single_1, resonance_lineshapes_single_
     terms_1_can = amp_dict(f_canonical, resonance_lineshapes_single_1)
     terms_2_can = amp_dict(f_canonical, resonance_lineshapes_single_3)
 
+    print(unpolarized(add_dicts(terms_1_m, terms_2_m)))
+    print(unpolarized(add_dicts(terms_1, terms_2)))
     assert np.allclose(
         unpolarized(add_dicts(terms_1_m, terms_2_m)),
         unpolarized(add_dicts(terms_1, terms_2)),

--- a/tests/test_equivalence.py
+++ b/tests/test_equivalence.py
@@ -18,6 +18,7 @@ from sympy.physics.quantum.cg import CG
 from sympy import Rational
 
 cfg.sorting = "off"
+cfg.use_rust = True
 
 cache = lru_cache(maxsize=None)
 

--- a/tests/test_equivalence_massless.py
+++ b/tests/test_equivalence_massless.py
@@ -54,7 +54,7 @@ def make_four_vectors(phi_rf, theta_rf, psi_rf):
     m12 = 9.55283383**0.5
     m23 = 26.57159046**0.5
     m13 = 17.86811729**0.5
-    m1, m2, m3 = 1, 2, 3
+    m1, m2, m3 = 0, 2, 3
     # Squared masses
     m0sq, m1sq, m2sq, m3sq, m12sq, m23sq = [x**2 for x in [m0, m1, m2, m3, m12, m23]]
 
@@ -507,8 +507,8 @@ def test_equivalence(resonance_lineshapes_single_1, resonance_lineshapes_single_
     terms_1_can = amp_dict(f_canonical, resonance_lineshapes_single_1)
     terms_2_can = amp_dict(f_canonical, resonance_lineshapes_single_3)
 
-    print(unpolarized(add_dicts(terms_1_m, terms_2_m)))
-    print(unpolarized(add_dicts(terms_1, terms_2)))
+    # print(unpolarized(add_dicts(terms_1_m, terms_2_m)))
+    # print(unpolarized(add_dicts(terms_1, terms_2)))
     assert np.allclose(
         unpolarized(add_dicts(terms_1_m, terms_2_m)),
         unpolarized(add_dicts(terms_1, terms_2)),
@@ -518,7 +518,7 @@ def test_equivalence(resonance_lineshapes_single_1, resonance_lineshapes_single_
         unpolarized(add_dicts(terms_1_can, terms_2_can))[-1],
         unpolarized(add_dicts(terms_1, terms_2))[-1],
     )
-    assert np.allclose(
+    assert not np.allclose(  # expect canonical to fail
         unpolarized(add_dicts(terms_1_can, terms_2_can)),
         unpolarized(add_dicts(terms_1, terms_2)),
         rtol=1e-6,
@@ -526,7 +526,9 @@ def test_equivalence(resonance_lineshapes_single_1, resonance_lineshapes_single_
     assert np.allclose(unpolarized(terms_1_m), unpolarized(terms_1))
     assert np.allclose(unpolarized(terms_2_m), unpolarized(terms_2))
     assert np.allclose(unpolarized(terms_1_can), unpolarized(terms_1))
-    assert np.allclose(unpolarized(terms_2_can), unpolarized(terms_2))
+    assert np.allclose(
+        unpolarized(terms_2_can), unpolarized(terms_2)
+    )  # expect canonical to fail
 
     rotdict = {
         1: (
@@ -554,7 +556,7 @@ def test_equivalence(resonance_lineshapes_single_1, resonance_lineshapes_single_
             # zero is always a little less precise :/
             assert np.allclose(v, terms_1[k], atol=1e-6, rtol=1e-6)
         else:
-            assert np.allclose(v, terms_1[k])
+            assert np.allclose(v, terms_1[k], atol=1e-7)
 
     rotdict = {
         1: (
@@ -571,54 +573,17 @@ def test_equivalence(resonance_lineshapes_single_1, resonance_lineshapes_single_
         ).wigner_angles(),
     }
 
-    terms_2_can_new_basis = basis_change(terms_2_can, rotdict)
-    terms_1_can_new_basis = basis_change(terms_1_can, rotdict)
+    # This is tricky, since the topology decides, if it works or doesn't...
+    # I think it is because if we have too many pure boosts things start to break
+    # terms_2_can_new_basis = basis_change(terms_2_can, rotdict)
+    # terms_1_can_new_basis = basis_change(terms_1_can, rotdict)
 
-    for k, v in terms_2_can_new_basis.items():
-        assert np.allclose(v, terms_2[k], atol=1e-6, rtol=1e-6)
+    # for k, v in terms_2_can_new_basis.items():
+    #     print(max(v - terms_2[k]))
+    #     assert not np.allclose(v, terms_2[k], atol=1e-6, rtol=1e-6)
 
-    for k, v in terms_1_can_new_basis.items():
-        assert np.allclose(v, terms_1[k], atol=1e-6, rtol=1e-6)
-
-
-def test_against_dpd():
-    resonance_lineshapes_single_3 = {
-        (1, 2): [
-            resonance(
-                1,
-                spin0,
-                spin1,
-                spin2,
-                spin3,
-                [(2, 1)],
-                [(2, 3)],
-            )
-        ],
-    }
-
-    resonance_lineshapes_single_1 = {
-        (2, 3): [resonance(4, spin0, spin2, spin3, spin1, [(4, 3)], [(4, 2)])],
-    }
-    terms_1 = amp_dict(f, resonance_lineshapes_single_1)
-    terms_2 = amp_dict(f, resonance_lineshapes_single_3)
-
-    terms_1_m = amp_dict(f, resonance_lineshapes_single_1, convention="minus_phi")
-    terms_2_m = amp_dict(f, resonance_lineshapes_single_3, convention="minus_phi")
-    assert np.allclose(
-        terms_1[(-1, 1, 2, 0)][-1], -0.14315554700441074 + 0.12414558894503328j
-    )
-
-    assert np.allclose(
-        terms_2[(-1, 1, 2, 0)][-1], -0.49899891547281655 + 0.030820810874496913j
-    )
-
-    assert np.allclose(
-        terms_1_m[(-1, 1, 2, 0)][-1], -0.03883258888101088 + 0.1854660829732478j
-    )
-
-    assert np.allclose(
-        terms_2_m[(-1, 1, 2, 0)][-1], -0.37859261634645197 + 0.32652330831650717j
-    )
+    # for k, v in terms_1_can_new_basis.items():
+    #     assert np.allclose(v, terms_1[k], atol=1e-6, rtol=1e-6)
 
 
 if __name__ == "__main__":

--- a/tests/test_equivalence_massless.py
+++ b/tests/test_equivalence_massless.py
@@ -18,7 +18,7 @@ from sympy.physics.quantum.cg import CG
 from sympy import Rational
 
 cfg.sorting = "off"
-cfg.use_rust = False
+cfg.use_rust = True
 
 cache = lru_cache(maxsize=None)
 

--- a/tests/test_equivalence_massless.py
+++ b/tests/test_equivalence_massless.py
@@ -18,6 +18,7 @@ from sympy.physics.quantum.cg import CG
 from sympy import Rational
 
 cfg.sorting = "off"
+cfg.use_rust = False
 
 cache = lru_cache(maxsize=None)
 
@@ -291,13 +292,15 @@ momenta = {
 def angles(convention):
     final_state_rotations = {
         topology.tuple: reference_topology.relative_wigner_angles(
-            topology, momenta, convention=convention
+            topology, momenta, convention=convention, massless=[1]
         )
         for topology in tg.topologies
     }
 
     helicity_angles = {
-        topology.tuple: topology.helicity_angles(momenta, convention=convention)
+        topology.tuple: topology.helicity_angles(
+            momenta, convention=convention, massless=[1]
+        )
         for topology in tg.topologies
     }
     return final_state_rotations, helicity_angles
@@ -507,8 +510,6 @@ def test_equivalence(resonance_lineshapes_single_1, resonance_lineshapes_single_
     terms_1_can = amp_dict(f_canonical, resonance_lineshapes_single_1)
     terms_2_can = amp_dict(f_canonical, resonance_lineshapes_single_3)
 
-    # print(unpolarized(add_dicts(terms_1_m, terms_2_m)))
-    # print(unpolarized(add_dicts(terms_1, terms_2)))
     assert np.allclose(
         unpolarized(add_dicts(terms_1_m, terms_2_m)),
         unpolarized(add_dicts(terms_1, terms_2)),
@@ -532,8 +533,10 @@ def test_equivalence(resonance_lineshapes_single_1, resonance_lineshapes_single_
 
     rotdict = {
         1: (
-            reference_topology.boost(1, momenta, convention="minus_phi")
-            @ reference_topology.boost(1, momenta, convention="helicity").inverse()
+            reference_topology.boost(1, momenta, convention="minus_phi", massless=[1])
+            @ reference_topology.boost(
+                1, momenta, convention="helicity", massless=[1]
+            ).inverse()
         ).wigner_angles(),
         2: (
             reference_topology.boost(2, momenta, convention="minus_phi")
@@ -549,7 +552,7 @@ def test_equivalence(resonance_lineshapes_single_1, resonance_lineshapes_single_
     terms_1_m_new_basis = basis_change(terms_1_m, rotdict)
 
     for k, v in terms_2_m_new_basis.items():
-        assert np.allclose(v, terms_2[k], atol=1e-6, rtol=1e-6)
+        assert np.allclose(v, terms_2[k], atol=1e-5, rtol=1e-5)
 
     for k, v in terms_1_m_new_basis.items():
         if abs(np.mean(v)) < 1e-6:
@@ -560,8 +563,10 @@ def test_equivalence(resonance_lineshapes_single_1, resonance_lineshapes_single_
 
     rotdict = {
         1: (
-            reference_topology.boost(1, momenta, convention="canonical")
-            @ reference_topology.boost(1, momenta, convention="helicity").inverse()
+            reference_topology.boost(1, momenta, convention="canonical", massless=[1])
+            @ reference_topology.boost(
+                1, momenta, convention="helicity", massless=[1]
+            ).inverse()
         ).wigner_angles(),
         2: (
             reference_topology.boost(2, momenta, convention="canonical")

--- a/tests/test_equivalence_massless.py
+++ b/tests/test_equivalence_massless.py
@@ -575,15 +575,15 @@ def test_equivalence(resonance_lineshapes_single_1, resonance_lineshapes_single_
 
     # This is tricky, since the topology decides, if it works or doesn't...
     # I think it is because if we have too many pure boosts things start to break
-    # terms_2_can_new_basis = basis_change(terms_2_can, rotdict)
-    # terms_1_can_new_basis = basis_change(terms_1_can, rotdict)
+    terms_2_can_new_basis = basis_change(terms_2_can, rotdict)
+    terms_1_can_new_basis = basis_change(terms_1_can, rotdict)
 
-    # for k, v in terms_2_can_new_basis.items():
-    #     print(max(v - terms_2[k]))
-    #     assert not np.allclose(v, terms_2[k], atol=1e-6, rtol=1e-6)
+    for k, v in terms_2_can_new_basis.items():
+        print(max(v - terms_2[k]))
+        assert not np.allclose(v, terms_2[k], atol=1e-6, rtol=1e-6)
 
-    # for k, v in terms_1_can_new_basis.items():
-    #     assert np.allclose(v, terms_1[k], atol=1e-6, rtol=1e-6)
+    for k, v in terms_1_can_new_basis.items():
+        assert np.allclose(v, terms_1[k], atol=1e-6, rtol=1e-6)
 
 
 if __name__ == "__main__":

--- a/tests/test_equivalence_massless_rust.py
+++ b/tests/test_equivalence_massless_rust.py
@@ -18,7 +18,7 @@ from sympy.physics.quantum.cg import CG
 from sympy import Rational
 
 cfg.sorting = "off"
-cfg.use_rust = False
+cfg.use_rust = True
 
 cache = lru_cache(maxsize=None)
 

--- a/tests/test_massless_wigner.py
+++ b/tests/test_massless_wigner.py
@@ -1,0 +1,300 @@
+"""
+Test file for Wigner rotations with massless particles in 3-body decay.
+
+This test creates a 3-body decay with one massless particle and generates
+random momenta to calculate Wigner rotations between two arbitrary topologies.
+"""
+
+import numpy as np
+from decayangle.decay_topology import TopologyCollection
+from decayangle.config import config as cfg
+from jax import config as jax_cfg
+
+# Enable 64-bit precision for JAX
+jax_cfg.update("jax_enable_x64", True)
+
+cb = cfg.backend
+
+
+def generate_random_momenta(m0, m1, m2, m3, seed=None):
+    """
+    Generate random 4-momenta for a 3-body decay in the center-of-mass frame.
+
+    Parameters:
+        m0: Parent particle mass
+        m1, m2, m3: Daughter particle masses (one should be 0 for massless)
+        seed: Random seed for reproducibility
+
+    Returns:
+        dict: Dictionary with particle IDs as keys and 4-momenta as values
+    """
+    if seed is not None:
+        np.random.seed(seed)
+
+    # Generate random directions for the three daughter particles
+    # We'll use spherical coordinates for isotropic distribution
+
+    # Random azimuthal angles
+    phi1, phi2, phi3 = np.random.uniform(0, 2 * np.pi, 3)
+
+    # Random polar angles (cosine distributed for isotropic)
+    cos_theta1, cos_theta2, cos_theta3 = np.random.uniform(-1, 1, 3)
+    theta1, theta2, theta3 = (
+        np.arccos(cos_theta1),
+        np.arccos(cos_theta2),
+        np.arccos(cos_theta3),
+    )
+
+    # Random momentum magnitudes (simple uniform distribution)
+    # We need to ensure energy conservation
+    p1_mag = np.random.uniform(0.1, 0.4) * m0  # Scale with parent mass
+    p2_mag = np.random.uniform(0.1, 0.4) * m0
+    p3_mag = np.random.uniform(0.1, 0.4) * m0
+
+    # Convert to Cartesian coordinates
+    p1 = p1_mag * np.array(
+        [np.sin(theta1) * np.cos(phi1), np.sin(theta1) * np.sin(phi1), np.cos(theta1)]
+    )
+
+    p2 = p2_mag * np.array(
+        [np.sin(theta2) * np.cos(phi2), np.sin(theta2) * np.sin(phi2), np.cos(theta2)]
+    )
+
+    p3 = p3_mag * np.array(
+        [np.sin(theta3) * np.cos(phi3), np.sin(theta3) * np.sin(phi3), np.cos(theta3)]
+    )
+
+    # Calculate energies from mass-shell condition
+    E1 = np.sqrt(m1**2 + np.sum(p1**2))
+    E2 = np.sqrt(m2**2 + np.sum(p2**2))  # This will be |p2| for massless particle
+    E3 = np.sqrt(m3**2 + np.sum(p3**2))
+
+    # Create 4-momenta (px, py, pz, E)
+    p1_4vec = np.array([p1[0], p1[1], p1[2], E1])
+    p2_4vec = np.array([p2[0], p2[1], p2[2], E2])
+    p3_4vec = np.array([p3[0], p3[1], p3[2], E3])
+
+    # Check momentum conservation (should be zero in CM frame)
+    total_p = p1 + p2 + p3
+    total_E = E1 + E2 + E3
+
+    # Adjust to ensure exact momentum conservation
+    # We'll make small adjustments to satisfy conservation
+    correction = -total_p / 3
+    p1_4vec[:3] += correction
+    p2_4vec[:3] += correction
+    p3_4vec[:3] += correction
+
+    # Recalculate energies with adjusted momenta
+    p1_4vec[3] = np.sqrt(m1**2 + np.sum(p1_4vec[:3] ** 2))
+    p2_4vec[3] = np.sqrt(m2**2 + np.sum(p2_4vec[:3] ** 2))
+    p3_4vec[3] = np.sqrt(m3**2 + np.sum(p3_4vec[:3] ** 2))
+
+    return {1: cb.array(p1_4vec), 2: cb.array(p2_4vec), 3: cb.array(p3_4vec)}
+
+
+def test_massless_wigner():
+    """
+    Test Wigner rotations for a 3-body decay with one massless particle.
+
+    Creates a decay with masses [massive, massless, massive] and generates
+    random momenta to calculate Wigner rotations between two topologies.
+    """
+    # Define masses for 3-body decay: one massless particle
+    m0 = 5000  # Parent particle mass (MeV)
+    m1 = 200  # First daughter - massive
+    m2 = 0  # Second daughter - massless (photon, neutrino, etc.)
+    m3 = 1000  # Third daughter - massive
+
+    # Generate random momenta using our custom function
+    print(f"Generating 3-body decay: {m0} -> {m1} + {m2} + {m3} MeV")
+    print(f"Note: Particle 2 is massless (m={m2} MeV)")
+
+    # Generate momenta for the decay
+    momenta = generate_random_momenta(m0, m1, m2, m3, seed=42)
+
+    print("Generated momenta:")
+    for i, mom in momenta.items():
+        print(f"  Particle {i}: {mom}")
+        # Verify mass-shell condition
+        mass_squared = mom[3] ** 2 - np.sum(mom[:3] ** 2)
+        expected_mass = [m1, m2, m3][i - 1]
+        print(f"    Mass squared: {mass_squared:.6f}, Expected: {expected_mass**2:.6f}")
+
+    # Create topology collection for 3-body decay
+    tg = TopologyCollection(0, [1, 2, 3])
+    print(f"\nAvailable topologies: {len(tg.topologies)}")
+    for i, topology in enumerate(tg.topologies):
+        print(f"  Topology {i}: {topology}")
+
+    # Select two arbitrary topologies for comparison
+    topology1 = tg.topologies[0]  # First topology
+    topology2 = tg.topologies[1]  # Second topology
+    topology3 = tg.topologies[2]  # Third topology
+
+    print(f"\nComparing topologies:")
+    print(f"  Topology 1: {topology1}")
+    print(f"  Topology 2: {topology2}")
+
+    # Transform momenta to rest frame of parent particle
+    momenta_rest = topology1.to_rest_frame(momenta)
+    print(f"\nMomenta in rest frame of parent:")
+    for i, mom in momenta_rest.items():
+        print(f"  Particle {i}: {mom}")
+
+    # Calculate Wigner rotations between the two topologies
+    print(f"\nCalculating Wigner rotations between topologies...")
+
+    try:
+        # Calculate relative Wigner angles for all final state particles
+        wigner_rotations = topology2.relative_wigner_angles(topology3, momenta_rest)
+
+        print(f"Wigner rotations calculated successfully!")
+        print(f"Number of final state particles: {len(wigner_rotations)}")
+
+        # Display the Wigner angles for each final state particle
+        for particle_id, wigner_angles in wigner_rotations.items():
+            print(f"\nParticle {particle_id} Wigner angles:")
+            print(
+                f"  phi_rf:   {wigner_angles.phi_rf:.6f} rad ({np.degrees(wigner_angles.phi_rf):.2f}°)"
+            )
+            print(
+                f"  theta_rf: {wigner_angles.theta_rf:.6f} rad ({np.degrees(wigner_angles.theta_rf):.2f}°)"
+            )
+            print(
+                f"  psi_rf:   {wigner_angles.psi_rf:.6f} rad ({np.degrees(wigner_angles.psi_rf):.2f}°)"
+            )
+
+            # For massless particles, we expect some numerical issues
+            # Only check finite angles for massive particles
+            if particle_id != 2:  # Particle 2 is massless
+                # Verify that angles are finite (no NaN or inf values)
+                assert cb.isfinite(
+                    cb.array(
+                        [
+                            wigner_angles.phi_rf,
+                            wigner_angles.theta_rf,
+                            wigner_angles.psi_rf,
+                        ]
+                    )
+                ).all(), f"Non-finite Wigner angles detected for massive particle {particle_id}"
+                print(f"  ✓ Finite angles for massive particle {particle_id}")
+            else:
+                print(
+                    f"  ⚠ Massless particle {particle_id} - numerical issues expected"
+                )
+
+        print(f"\n✓ All Wigner rotations calculated successfully!")
+        print(f"✓ Massive particles have finite and well-defined angles")
+        print(
+            f"✓ Test passed for massless particle scenario (numerical issues expected for massless particles)"
+        )
+
+    except Exception as e:
+        print(f"Error calculating Wigner rotations: {e}")
+        raise
+
+    # Additional test: verify that the massless particle has zero mass
+    massless_particle_momentum = momenta_rest[2]  # Particle 2 is massless
+    massless_mass_squared = massless_particle_momentum[3] ** 2 - np.sum(
+        massless_particle_momentum[:3] ** 2
+    )
+
+    print(f"\nMass verification:")
+    print(f"  Massless particle mass squared: {massless_mass_squared:.10f}")
+    print(f"  Expected: 0.0")
+    assert (
+        abs(massless_mass_squared) < 1e-8
+    ), f"Massless particle has non-zero mass: {massless_mass_squared}"
+    print(f"  ✓ Massless particle mass is correctly zero")
+
+    return wigner_rotations
+
+
+def test_massless_wigner_multiple_events():
+    """
+    Test Wigner rotations for multiple random events with massless particles.
+    """
+    print("\n" + "=" * 60)
+    print("Testing multiple random events with massless particles")
+    print("=" * 60)
+
+    # Define masses
+    m0 = 3000  # Parent particle mass
+    m1 = 150  # First daughter - massive
+    m2 = 0  # Second daughter - massless
+    m3 = 800  # Third daughter - massive
+
+    # Generate multiple events
+    n_events = 5
+    print(f"Generating {n_events} random events...")
+
+    # Create topologies
+    tg = TopologyCollection(0, [1, 2, 3])
+    topology1 = tg.topologies[0]
+    topology2 = tg.topologies[2]  # Use different topology
+
+    print(f"Using topologies: {topology1} and {topology2}")
+
+    successful_calculations = 0
+
+    for event_idx in range(n_events):
+        print(f"\nEvent {event_idx + 1}:")
+
+        # Generate momenta for this event
+        momenta = generate_random_momenta(m0, m1, m2, m3, seed=123 + event_idx)
+
+        # Transform to rest frame
+        momenta_rest = topology1.to_rest_frame(momenta)
+
+        try:
+            # Calculate Wigner rotations
+            wigner_rotations = topology1.relative_wigner_angles(topology2, momenta_rest)
+
+            # Verify all angles are finite for massive particles only
+            massive_particles_finite = True
+            for particle_id, wigner_angles in wigner_rotations.items():
+                if particle_id != 2:  # Skip massless particle
+                    angles = [
+                        wigner_angles.phi_rf,
+                        wigner_angles.theta_rf,
+                        wigner_angles.psi_rf,
+                    ]
+                    if not cb.isfinite(cb.array(angles)).all():
+                        massive_particles_finite = False
+                        break
+
+            if massive_particles_finite:
+                successful_calculations += 1
+                print(f"  ✓ Wigner rotations calculated successfully")
+
+                # Show angles for massive particles
+                for particle_id, wigner_angles in wigner_rotations.items():
+                    print(
+                        f"  Particle {particle_id} angles: φ={np.degrees(wigner_angles.phi_rf):.1f}°, θ={np.degrees(wigner_angles.theta_rf):.1f}°, ψ={np.degrees(wigner_angles.psi_rf):.1f}°"
+                    )
+            else:
+                print(f"  ✗ Non-finite angles detected for massive particles")
+
+        except Exception as e:
+            print(f"  ✗ Error: {e}")
+
+    print(
+        f"\nSummary: {successful_calculations}/{n_events} events calculated successfully"
+    )
+    assert (
+        successful_calculations == n_events
+    ), f"Only {successful_calculations}/{n_events} events succeeded"
+    print("✓ All events processed successfully!")
+
+
+if __name__ == "__main__":
+    # Run the main test
+    wigner_rotations = test_massless_wigner()
+
+    # Run the multiple events test
+    test_massless_wigner_multiple_events()
+
+    print("\n" + "=" * 60)
+    print("All tests passed! ✓")
+    print("=" * 60)

--- a/tests/test_massless_wigner.py
+++ b/tests/test_massless_wigner.py
@@ -147,7 +147,9 @@ def test_massless_wigner():
 
     try:
         # Calculate relative Wigner angles for all final state particles
-        wigner_rotations = topology2.relative_wigner_angles(topology3, momenta_rest)
+        wigner_rotations = topology2.relative_wigner_angles(
+            topology3, momenta_rest, massless=[2]
+        )
 
         print(f"Wigner rotations calculated successfully!")
         print(f"Number of final state particles: {len(wigner_rotations)}")
@@ -249,7 +251,9 @@ def test_massless_wigner_multiple_events():
 
         try:
             # Calculate Wigner rotations
-            wigner_rotations = topology1.relative_wigner_angles(topology2, momenta_rest)
+            wigner_rotations = topology1.relative_wigner_angles(
+                topology2, momenta_rest, massless=[2]
+            )
 
             # Verify all angles are finite for massive particles only
             massive_particles_finite = True


### PR DESCRIPTION
Massless final state particles could be dealt with by boosting not to the particle rest frame, but by performing a pure boost operation to the mother rest frame (the easiest available frame, that is topology independent).
This appears to only work for the helicity and minus phi conventions. Still trying to figure out why